### PR TITLE
feat: add page_diagnose tool and view=visual layout tree

### DIFF
--- a/includes/MCP/Router.php
+++ b/includes/MCP/Router.php
@@ -96,8 +96,10 @@ final class Router {
 		// Bricks is a theme, so \Bricks\Elements isn't available on plugins_loaded.
 		if ( did_action( 'after_setup_theme' ) ) {
 			$this->register_bricks_tools();
+			$this->register_output_schemas();
 		} else {
 			add_action( 'after_setup_theme', array( $this, 'register_bricks_tools' ), 20 );
+			add_action( 'after_setup_theme', array( $this, 'register_output_schemas' ), 25 );
 		}
 
 		// Flush schema cache when plugins are updated.
@@ -120,7 +122,7 @@ final class Router {
 		// Get site info tool.
 		$this->register_tool(
 			'get_site_info',
-			__( "Get WordPress site information.\n\nActions:\n- info: Basic site info (default)\n- diagnose: Run connection diagnostics (REST API, App Passwords, security plugins, hosting provider, MCP endpoint)", 'bricks-mcp' ),
+			__( "Get WordPress site info or run MCP connection diagnostics. Call with action=diagnose when troubleshooting connection issues.\n\nActions:\n- info: Site name, URL, version, timezone, charset (default)\n- diagnose: Full connection health check — REST API, App Passwords, security plugins, hosting, MCP endpoint status", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -132,12 +134,19 @@ final class Router {
 				),
 			),
 			array( $this, 'tool_get_site_info' )
+		,
+		array(
+			'readOnlyHint'    => true,
+			'destructiveHint' => false,
+			'idempotentHint'  => true,
+			'openWorldHint'   => false,
+		)
 		);
 
 		// WordPress consolidated tool (replaces get_posts, get_post, get_users, get_plugins).
 		$this->register_tool(
 			'wordpress',
-			__( "Query WordPress data.\n\nActions:\n- get_posts: List published posts (optional: post_type, posts_per_page, orderby, order)\n- get_post: Get single post/page by ID (requires: id)\n- get_users: List users (no required params)\n- get_plugins: List plugins (no required params)", 'bricks-mcp' ),
+			__( "Read WordPress posts, users, and plugins. Use this for general WordPress data queries not specific to Bricks.\n\nWHEN: Use get_posts to list content before editing. Use get_plugins to check if a plugin is active before using its features. Use get_users to find author IDs.\n\nActions:\n- get_posts: List posts (optional: post_type, posts_per_page=20, orderby, order)\n- get_post: Single post by ID (requires: id)\n- get_users: List users (optional: role, number)\n- get_plugins: List all plugins with active status (optional: status=all|active|inactive)", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -188,6 +197,13 @@ final class Router {
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_wordpress' )
+		,
+		array(
+			'readOnlyHint'    => true,
+			'destructiveHint' => false,
+			'idempotentHint'  => true,
+			'openWorldHint'   => false,
+		)
 		);
 
 		/**
@@ -209,13 +225,20 @@ final class Router {
 	 * @param callable $handler          Tool handler callback.
 	 * @return void
 	 */
-	public function register_tool( string $name, string $description, array $input_schema, callable $handler ): void {
-		$this->tools[ $name ] = array(
+	public function register_tool( string $name, string $description, array $input_schema, callable $handler, array $annotations = [], array $output_schema = [] ): void {
+		$entry = array(
 			'name'        => $name,
 			'description' => $description,
 			'inputSchema' => $input_schema,
 			'handler'     => $handler,
 		);
+		if ( ! empty( $annotations ) ) {
+			$entry['annotations'] = $annotations;
+		}
+		if ( ! empty( $output_schema ) ) {
+			$entry['outputSchema'] = $output_schema;
+		}
+		$this->tools[ $name ] = $entry;
 	}
 
 	/**
@@ -236,11 +259,18 @@ final class Router {
 		$tools = array();
 
 		foreach ( $this->tools as $tool ) {
-			$tools[] = array(
+			$entry = array(
 				'name'        => $tool['name'],
 				'description' => $tool['description'],
 				'inputSchema' => $tool['inputSchema'],
 			);
+			if ( ! empty( $tool['annotations'] ) ) {
+				$entry['annotations'] = $tool['annotations'];
+			}
+			if ( ! empty( $tool['outputSchema'] ) ) {
+				$entry['outputSchema'] = $tool['outputSchema'];
+			}
+			$tools[] = $entry;
 		}
 
 		return $tools;
@@ -275,6 +305,13 @@ final class Router {
 			);
 		}
 
+		// Apply smart defaults to reduce required parameters (Issue #26).
+		$arguments = $this->apply_smart_defaults( $name, $arguments );
+
+		// Strip meta-params before passing to handlers (response_format is consumed above).
+		$handler_args = $arguments;
+		unset( $handler_args['response_format'] );
+
 		// Validate tool arguments against inputSchema.
 		$validation = $this->validation_service->validate_arguments( $arguments, $tool['inputSchema'], $name );
 		if ( is_wp_error( $validation ) ) {
@@ -286,10 +323,16 @@ final class Router {
 		}
 
 		try {
-			$result = call_user_func( $tool['handler'], $arguments );
+			$result = call_user_func( $tool['handler'], $handler_args );
 
 			if ( is_wp_error( $result ) ) {
 				return Response::tool_error( $result );
+			}
+
+			// Apply response_format optimization (Issue #23).
+			$response_format = $arguments['response_format'] ?? 'full';
+			if ( 'minimal' === $response_format && is_array( $result ) ) {
+				$result = $this->apply_minimal_format( $result );
 			}
 
 			return Response::success(
@@ -553,6 +596,89 @@ final class Router {
 	 *
 	 * @return void
 	 */
+		/**
+	 * Register output schemas for key tools (Issue #25).
+	 *
+	 * Adds structured output type hints so MCP clients can validate
+	 * and display responses more intelligently.
+	 *
+	 * @return void
+	 */
+	public function register_output_schemas(): void {
+		$page_schema = [
+			'type' => 'object',
+			'properties' => [
+				'id'            => ['type'=>'integer'],
+				'title'         => ['type'=>'string'],
+				'status'        => ['type'=>'string'],
+				'permalink'     => ['type'=>'string'],
+				'element_count' => ['type'=>'integer'],
+			],
+		];
+		$element_schema = [
+			'type' => 'object',
+			'properties' => [
+				'id'         => ['type'=>'string'],
+				'name'       => ['type'=>'string'],
+				'parent'     => ['type'=>['string','integer']],
+				'children'   => ['type'=>'array'],
+				'settings'   => ['type'=>'object'],
+			],
+		];
+		$diagnose_schema = [
+			'type' => 'object',
+			'properties' => [
+				'post_id'       => ['type'=>'integer'],
+				'status'        => ['type'=>'string','enum'=>['clean','warnings','errors']],
+				'issue_count'   => ['type'=>'integer'],
+				'error_count'   => ['type'=>'integer'],
+				'warning_count' => ['type'=>'integer'],
+				'issues'        => [
+					'type'=>'array',
+					'items'=>[
+						'type'=>'object',
+						'properties'=>[
+							'element_id'=>['type'=>['string','null']],
+							'severity'  =>['type'=>'string','enum'=>['error','warning']],
+							'type'      =>['type'=>'string'],
+							'message'   =>['type'=>'string'],
+							'fix'       =>['type'=>'string'],
+						],
+					],
+				],
+			],
+		];
+
+		// Attach output schemas to registered tools.
+		if ( isset( $this->tools['page'] ) ) {
+			$this->tools['page']['outputSchema'] = ['type'=>'object','description'=>'Page data, element tree, or list of pages depending on action'];
+		}
+		if ( isset( $this->tools['page_diagnose'] ) ) {
+			$this->tools['page_diagnose']['outputSchema'] = $diagnose_schema;
+		}
+		if ( isset( $this->tools['element'] ) ) {
+			$this->tools['element']['outputSchema'] = ['type'=>'object','description'=>'Element operation result with affected element ID and page element count'];
+		}
+		if ( isset( $this->tools['template'] ) ) {
+			$this->tools['template']['outputSchema'] = ['type'=>'object','description'=>'Template data including id, title, type, status, and element array'];
+		}
+		if ( isset( $this->tools['global_class'] ) ) {
+			$this->tools['global_class']['outputSchema'] = ['type'=>'object','description'=>'Global class operation result with class name, id, and styles'];
+		}
+		if ( isset( $this->tools['get_site_info'] ) ) {
+			$this->tools['get_site_info']['outputSchema'] = [
+				'type'=>'object',
+				'properties'=>[
+					'name'       =>['type'=>'string'],
+					'url'        =>['type'=>'string'],
+					'version'    =>['type'=>'string'],
+					'language'   =>['type'=>'string'],
+					'timezone'   =>['type'=>'string'],
+				],
+			];
+		}
+	}
+
 	public function register_bricks_tools(): void {
 		// Gate: skip registration when Bricks is not installed.
 		if ( ! $this->bricks_service->is_bricks_active() ) {
@@ -562,7 +688,7 @@ final class Router {
 		// Tool: get_builder_guide.
 		$this->register_tool(
 			'get_builder_guide',
-			__( 'Get the Bricks MCP builder guide with patterns, element settings reference, CSS gotchas, animation format, and workflow tips. Call this FIRST before building or modifying pages — it teaches you how to use the other tools efficiently.', 'bricks-mcp' ),
+			__( 'Essential reference for building with Bricks via MCP. Call this FIRST in any new conversation before building or editing pages. Contains element settings format, CSS composite keys, animation patterns, workflow tips, and common gotchas. Use section= to fetch only what you need.', 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -574,12 +700,19 @@ final class Router {
 				),
 			),
 			array( $this, 'tool_get_builder_guide' )
+		,
+		array(
+			'readOnlyHint'    => true,
+			'destructiveHint' => false,
+			'idempotentHint'  => true,
+			'openWorldHint'   => false,
+		)
 		);
 
 		// Bricks consolidated tool (replaces enable_bricks, disable_bricks, get_bricks_settings, get_breakpoints, get_element_schemas).
 		$this->register_tool(
 			'bricks',
-			__( "Manage Bricks Builder settings and schema.\n\nActions:\n- enable: Enable Bricks editor on a post (requires: post_id)\n- disable: Disable Bricks editor on a post (requires: post_id)\n- get_settings: Get Bricks global settings (optional: category)\n- get_breakpoints: Get responsive breakpoints (no required params)\n- get_element_schemas: Get element type schemas (optional: element, catalog_only)\n- get_dynamic_tags: List available dynamic data tags for embedding in element settings (optional: group)\n- get_query_types: Get query loop object types and their settings schema (no required params)\n- get_form_schema: Get form element field types, action settings keys, and example form patterns (no required params)\n- get_interaction_schema: Get element interaction/animation triggers, actions, animation types, and example patterns (no required params)\n- get_component_schema: Get component property types, slot mechanics, and instantiation patterns (no required params)\n- get_popup_schema: Get popup display settings keys, trigger patterns, and popup creation workflow (no required params)\n- get_filter_schema: Get Bricks query filter element types, required settings, and setup workflow (no required params)\n- get_condition_schema: Get element visibility condition types, groups, compare operators, value types, and examples (no required params)\n- get_global_queries: List all reusable global query definitions (no required params)\n- set_global_query: Create or update a reusable global query (requires: name, settings; optional: query_id for update, category)\n- delete_global_query: Delete a global query by ID (requires: query_id)", 'bricks-mcp' ),
+			__( "Manage Bricks Builder settings, schemas, and global queries. Use schema actions to learn element/form/interaction formats before building.\n\nWHEN: Call get_element_schemas(catalog_only=true) to browse available elements. Call get_breakpoints to understand responsive keys. Call get_interaction_schema before adding animations. Call get_condition_schema before setting element visibility.\n\nActions:\n- enable/disable: Toggle Bricks editor on a post (requires: post_id)\n- get_settings: Global Bricks settings (optional: category)\n- get_breakpoints: Responsive breakpoint keys and composite key format\n- get_element_schemas: Element schemas (optional: element=name for one; catalog_only=true for name list)\n- get_dynamic_tags: Available dynamic data tags (optional: group filter)\n- get_query_types: Query loop object types and settings keys\n- get_form_schema: Form field types, action keys, and examples\n- get_interaction_schema: Interaction triggers, actions, animation types\n- get_component_schema: Component property types and slot mechanics\n- get_popup_schema: Popup display settings and trigger patterns\n- get_filter_schema: Query filter element types and setup workflow\n- get_condition_schema: Element visibility condition types and operators\n- get_global_queries: List reusable global query definitions\n- set_global_query: Create/update global query (requires: name, settings)\n- delete_global_query: Delete global query (requires: query_id)", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -625,12 +758,18 @@ final class Router {
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_bricks' )
-		);
+		,
+array(
+'readOnlyHint'=>false,
+'destructiveHint'=>false,
+'idempotentHint'=>false,
+'openWorldHint'=>false,
+));
 
 		// Page consolidated tool (replaces list_pages, search_pages, get_bricks_content, create_bricks_page, update_bricks_content, update_page, delete_page, duplicate_page, get_page_settings, update_page_settings + SEO).
 		$this->register_tool(
 			'page',
-			__( "Manage pages and Bricks content.\n\nActions:\n- list: List pages/posts (optional: post_type, status, posts_per_page, paged, bricks_only)\n- search: Search Bricks pages (requires: search; optional: post_type, posts_per_page, paged)\n- get: Get page with Bricks element data (requires: post_id; optional: view)\n- create: Create page with Bricks content (requires: title; optional: post_type, status, elements)\n- update_content: Update Bricks elements (requires: post_id, elements)\n- update_meta: Update page title/status (requires: post_id; optional: title, status, slug)\n- delete: Delete page (requires: post_id)\n- duplicate: Duplicate page (requires: post_id)\n- get_settings: Get page settings (requires: post_id)\n- update_settings: Update page settings (requires: post_id, settings)\n- get_seo: Get SEO data from active plugin with audit (requires: post_id)\n- update_seo: Update SEO fields via active plugin (requires: post_id; optional: title, description, robots_noindex, robots_nofollow, canonical, og_title, og_description, og_image, twitter_title, twitter_description, twitter_image, focus_keyword)", 'bricks-mcp' ),
+			__( "Read and write Bricks pages, posts, and their element content. Use this for every page-level operation.\n\nWHEN: Use page:get view=visual FIRST before editing any existing page to see the full layout tree with element IDs. Use page:list to discover pages. Use page:update_content to replace all elements.\n\nActions:\n- list: List pages (optional: post_type, status, posts_per_page, bricks_only=true)\n- search: Search Bricks pages (requires: search)\n- get: Get page with elements (requires: post_id; optional: view=visual|summary|detail)\n- create: Create page (requires: title; optional: post_type, status, elements)\n- update_content: Replace all Bricks elements (requires: post_id, elements) — destructive\n- update_meta: Update title/slug/status (requires: post_id)\n- delete: Trash page (requires: post_id) — destructive\n- duplicate: Clone page (requires: post_id)\n- get_settings: Get page-level Bricks settings (requires: post_id)\n- update_settings: Update page-level settings (requires: post_id, settings)\n- get_seo: Get SEO data with audit (requires: post_id)\n- update_seo: Write SEO fields (requires: post_id; optional: title, description, og_title, og_image, focus_keyword)", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -671,7 +810,7 @@ final class Router {
 					'view'                => array(
 						'type'        => 'string',
 						'enum'        => array( 'detail', 'summary', 'visual' ),
-						'description' => __( 'Detail level (get: detail=full settings, summary=type counts + tree, visual=human-readable layout tree with element IDs, global classes, and content hints - use before editing existing pages)', 'bricks-mcp' ),
+						'description' => __( 'Detail level for page:get. visual = human-readable nested tree with element IDs, labels, text previews, bg colors — USE THIS before editing existing pages. summary = element type counts + tree structure. detail = full raw settings (large).', 'bricks-mcp' ),
 					),
 					'title'               => array(
 						'type'        => 'string',
@@ -736,13 +875,19 @@ final class Router {
 				),
 				'required'   => array( 'action' ),
 			),
-			array( $this, 'tool_page' )
+			array( $this, 'tool_page' ),
+		array(
+			'readOnlyHint'    => false,
+			'destructiveHint' => true,
+			'idempotentHint'  => false,
+			'openWorldHint'   => false,
+		)
 		);
 
 		// page_diagnose: scan existing pages for known issues before editing.
 $this->register_tool(
     'page_diagnose',
-    __( 'Scan a Bricks page or template for issues before editing. Returns structured report with element ID, severity, type, message, and fix for each issue found. Checks: scripts missing <script> tags, %root% in _cssCustom, _maxWidth key, plain-string colors, invalid breakpoint keys, orphaned children, phantom _bricks_page_content_2 on header/footer templates, missing global classes, integer border values, and code elements with PHP that lack executeCode. Call this before editing any existing page. Read-only - makes no changes.', 'bricks-mcp' ),
+    __( 'Pre-edit health check for any Bricks page or template. Returns issues with severity, element ID, and actionable fix. Call this before editing existing pages to avoid building on a broken foundation. Read-only — never modifies data. Checks 10 common issues: missing script tags, %root% in CSS, wrong keys (_maxWidth), plain hex colors, invalid breakpoints, orphaned children, phantom content on headers/footers, missing global classes, integer border values, PHP without executeCode.', 'bricks-mcp' ),
     array(
         'type'       => 'object',
         'properties' => array(
@@ -754,12 +899,18 @@ $this->register_tool(
         'required' => array( 'post_id' ),
     ),
     array( $this, 'tool_page_diagnose' )
-);
+,
+array(
+'readOnlyHint'=>true,
+'destructiveHint'=>false,
+'idempotentHint'=>true,
+'openWorldHint'=>false,
+));
 
 		// Element consolidated tool (replaces add_element, update_element, remove_element).
 		$this->register_tool(
 			'element',
-			__( "Manage individual Bricks elements on a page.\n\nActions:\n- add: Add element to page (requires: post_id, name; optional: parent_id, position, settings)\n- update: Update element settings (requires: post_id, element_id, settings)\n- remove: Remove element from page (requires: post_id, element_id)\n- get_conditions: Get element visibility conditions (requires: post_id, element_id)\n- set_conditions: Set element visibility conditions (requires: post_id, element_id, conditions)\n- move: Move/reorder element within page (requires: post_id, element_id; optional: target_parent_id, position)\n- bulk_update: Update settings on multiple elements (requires: post_id, updates)", 'bricks-mcp' ),
+			__( "Add, update, move, or remove individual elements on a Bricks page. Use page:get view=visual first to get element IDs before calling this.\n\nWHEN: Use element:add to insert new elements. Use element:update to change settings on a specific element. Use element:bulk_update to change multiple elements in one call (more efficient). Use element:remove to delete an element and all its children.\n\nActions:\n- add: Insert element (requires: post_id, name; optional: parent_id=0, position, settings)\n- update: Update element settings — merges with existing (requires: post_id, element_id, settings)\n- remove: Delete element + children (requires: post_id, element_id) — destructive\n- get_conditions: Get visibility conditions (requires: post_id, element_id)\n- set_conditions: Set visibility conditions (requires: post_id, element_id, conditions)\n- move: Reorder element (requires: post_id, element_id; optional: target_parent_id, position)\n- bulk_update: Update many elements at once (requires: post_id, updates array; max 50)", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -825,12 +976,18 @@ $this->register_tool(
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_element' )
-		);
+		,
+array(
+'readOnlyHint'=>false,
+'destructiveHint'=>false,
+'idempotentHint'=>false,
+'openWorldHint'=>false,
+));
 
 		// Template consolidated tool (replaces list_templates, get_template_content, create_template, update_template, delete_template, duplicate_template).
 		$this->register_tool(
 			'template',
-			__( "Manage Bricks templates (headers, footers, sections, popups, etc.).\n\nActions:\n- list: List templates (optional: type, status, tag, bundle)\n- get: Get template with element content (requires: template_id)\n- create: Create template (requires: title, type; optional: elements, status, tags, bundles)\n- update: Update template metadata (requires: template_id; optional: title, status, type, tags, bundles)\n- delete: Delete template (requires: template_id)\n- duplicate: Duplicate template (requires: template_id; optional: title)\n- get_popup_settings: Get popup display settings (requires: template_id; template must be type popup)\n- set_popup_settings: Set popup display settings (requires: template_id, settings; template must be type popup)\n- export: Export template as Bricks-compatible JSON (requires: template_id; optional: include_classes)\n- import: Import template from JSON data (requires: template_data)\n- import_url: Import template from remote URL (requires: url)", 'bricks-mcp' ),
+			__( "Create, read, update, and delete Bricks templates (headers, footers, popups, sections). Use template_condition to control which pages each template appears on.\n\nWHEN: Use template:create then template_condition:set to deploy a header or footer. Use template:get to inspect element structure. Use template:export/import to move templates between sites.\n\nActions:\n- list: List templates (optional: type, status, tag, bundle)\n- get: Get full element content (requires: template_id)\n- create: Create template (requires: title, type; optional: elements, status)\n- update: Update title/status/type (requires: template_id)\n- delete: Trash template (requires: template_id) — destructive\n- duplicate: Clone template (requires: template_id)\n- get_popup_settings / set_popup_settings: Manage popup display rules (requires: template_id)\n- export: Export as JSON (requires: template_id)\n- import: Import from JSON data (requires: template_data)\n- import_url: Import from remote URL (requires: url)", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -906,13 +1063,14 @@ $this->register_tool(
 				),
 				'required'   => array( 'action' ),
 			),
-			array( $this, 'tool_template' )
+			array( $this, 'tool_template' ),
+		array('readOnlyHint'=>false,'destructiveHint'=>true,'idempotentHint'=>false,'openWorldHint'=>false)
 		);
 
 		// Template condition consolidated tool (replaces get_condition_types, set_template_conditions, resolve_templates).
 		$this->register_tool(
 			'template_condition',
-			__( "Manage Bricks template conditions (which templates apply where).\n\nActions:\n- get_types: List available condition types (no required params)\n- set: Set template conditions (requires: template_id, conditions)\n- resolve: Find which templates apply to a post (optional: post_id, post_type)", 'bricks-mcp' ),
+			__( "Control which pages each Bricks template targets. Higher score conditions win when multiple templates compete. Essential after creating headers, footers, and WooCommerce templates.\n\nWHEN: After creating any template with template:create, call template_condition:set to activate it. Use get_types to see all condition formats. Use resolve to debug which templates are loading on a specific page.\n\nActions:\n- get_types: All condition types with scoring explanation (no params)\n- set: Activate template on pages (requires: template_id, conditions array; empty array deactivates)\n- resolve: Which templates win for a post (optional: post_id, post_type)", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -941,12 +1099,19 @@ $this->register_tool(
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_template_condition' )
+		,
+		array(
+			'readOnlyHint'    => false,
+			'destructiveHint' => false,
+			'idempotentHint'  => true,
+			'openWorldHint'   => false,
+		)
 		);
 
 		// Template taxonomy consolidated tool (replaces list_template_tags, list_template_bundles, create_template_tag, create_template_bundle, delete_template_tag, delete_template_bundle).
 		$this->register_tool(
 			'template_taxonomy',
-			__( "Manage Bricks template tags and bundles.\n\nActions:\n- list_tags: List all template tags (no required params)\n- list_bundles: List all template bundles (no required params)\n- create_tag: Create template tag (requires: name)\n- create_bundle: Create template bundle (requires: name)\n- delete_tag: Delete template tag (requires: term_id)\n- delete_bundle: Delete template bundle (requires: term_id)", 'bricks-mcp' ),
+			__( "Manage template tags and bundles for organising and filtering Bricks templates. Tags and bundles are taxonomy terms assigned to templates.\n\nWHEN: Create tags/bundles first, then assign to templates via template:create or template:update. Use list_tags to see existing terms before creating duplicates.\n\nActions:\n- list_tags / list_bundles: List all terms\n- create_tag / create_bundle: New term (requires: name)\n- delete_tag / delete_bundle: Remove term (requires: term_id) — unassigned from all templates", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -967,12 +1132,19 @@ $this->register_tool(
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_template_taxonomy' )
+		,
+		array(
+			'readOnlyHint'    => false,
+			'destructiveHint' => true,
+			'idempotentHint'  => false,
+			'openWorldHint'   => false,
+		)
 		);
 
 		// Global class consolidated tool (replaces get_global_classes, create_global_class, update_global_class, delete_global_class, apply_global_class, remove_global_class, batch_create_global_classes, batch_delete_global_classes, import_classes_from_css, list_global_class_categories, create_global_class_category, delete_global_class_category).
 		$this->register_tool(
 			'global_class',
-			__( "Manage Bricks global CSS classes.\n\nActions:\n- list: List global classes (optional: category, search)\n- create: Create class (requires: name; optional: styles, color, category)\n- update: Update class styles (requires: class_name; optional: styles, color, category, replace_styles)\n- delete: Delete/trash class (requires: class_name)\n- apply: Apply class to elements (requires: post_id, element_ids, class_name)\n- remove: Remove class from elements (requires: post_id, element_ids, class_name)\n- batch_create: Create multiple classes (requires: classes)\n- batch_delete: Delete multiple classes (requires: classes)\n- import_css: Import CSS as global classes (requires: css)\n- list_categories: List class categories (no required params)\n- create_category: Create category (requires: category_name)\n- delete_category: Delete category (requires: category_id)\n- export: Export global classes as JSON (optional: category)\n- import_json: Import global classes from JSON data (requires: classes_data)", 'bricks-mcp' ),
+			__( "Manage reusable Bricks CSS classes that apply styles across multiple elements. Changes here affect every element using the class sitewide.\n\nWHEN: Create classes for repeated styles (buttons, cards, spacing). Use apply/remove to assign classes to elements instead of duplicating inline styles. Use import_css to bulk-create from existing stylesheets.\n\nActions:\n- list: List classes (optional: search, category)\n- create: Create class (requires: name; optional: styles, color, category)\n- update: Merge styles into class (requires: class_name; optional: styles, replace_styles=false)\n- delete: Trash class (requires: class_name) — destructive\n- apply: Add class to elements (requires: post_id, element_ids, class_name)\n- remove: Remove class from elements (requires: post_id, element_ids, class_name)\n- batch_create: Create multiple classes at once (requires: classes array)\n- batch_delete: Delete multiple classes (requires: classes array)\n- import_css: Parse raw CSS into global classes (requires: css)\n- list_categories / create_category / delete_category: Manage class groupings\n- export: Export as JSON (optional: category)\n- import_json: Import from JSON (requires: classes_data)", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -1041,13 +1213,14 @@ $this->register_tool(
 				),
 				'required'   => array( 'action' ),
 			),
-			array( $this, 'tool_global_class' )
+			array( $this, 'tool_global_class' ),
+		array('readOnlyHint'=>false,'destructiveHint'=>true,'idempotentHint'=>false,'openWorldHint'=>false)
 		);
 
 		// Theme style consolidated tool (replaces list_theme_styles, get_theme_style, create_theme_style, update_theme_style, delete_theme_style).
 		$this->register_tool(
 			'theme_style',
-			__( "Manage Bricks theme styles (site-wide typography, colors, spacing).\n\nActions:\n- list: List all theme styles (no required params)\n- get: Get theme style details (requires: style_id)\n- create: Create theme style (requires: name; optional: styles, conditions)\n- update: Update theme style (requires: style_id; optional: name, styles, conditions, active)\n- delete: Delete theme style (requires: style_id)", 'bricks-mcp' ),
+			__( "Manage site-wide Bricks theme styles — typography, colors, spacing, and button defaults. Styles apply conditionally based on template conditions. Changes affect every page the style targets.\n\nWHEN: Create a style with conditions to apply different typography per page type. Use update(replace_section=true) to completely swap a settings group. Use list to check active styles before creating new ones to avoid conflicts.\n\nActions:\n- list: All theme styles with condition_types reference\n- get: Full style details (requires: style_id)\n- create: New style (requires: name; optional: styles object, conditions)\n- update: Modify style (requires: style_id; optional: name, styles, conditions, active, replace_section)\n- delete: Remove/deactivate style (requires: style_id; optional: hard_delete=false)", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -1089,12 +1262,19 @@ $this->register_tool(
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_theme_style' )
+		,
+		array(
+			'readOnlyHint'    => false,
+			'destructiveHint' => true,
+			'idempotentHint'  => false,
+			'openWorldHint'   => false,
+		)
 		);
 
 		// Typography scale consolidated tool (replaces get_typography_scales, create_typography_scale, update_typography_scale, delete_typography_scale).
 		$this->register_tool(
 			'typography_scale',
-			__( "Manage Bricks typography scales.\n\nActions:\n- list: List typography scales (no required params)\n- create: Create typography scale (requires: name, settings)\n- update: Update typography scale (requires: scale_id; optional: name, settings)\n- delete: Delete typography scale (requires: scale_id)", 'bricks-mcp' ),
+			__( "Manage Bricks typography scales — CSS custom property steps (--text-sm, --text-md, etc.) that generate utility classes. Use var(--prefix-step) in typography settings to reference scales.\n\nWHEN: Create a scale to establish a consistent type system across the site. Use list to check existing scales before creating. Scales generate both CSS variables and utility classes automatically.\n\nActions:\n- list: All scales with prefix and steps\n- create: New scale (requires: name, prefix=--text-, steps=[{name,value}])\n- update: Modify scale (requires: scale_id)\n- delete: Remove scale (requires: scale_id) — CSS variables removed after Bricks regenerates", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -1131,12 +1311,19 @@ $this->register_tool(
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_typography_scale' )
+		,
+		array(
+			'readOnlyHint'    => false,
+			'destructiveHint' => true,
+			'idempotentHint'  => false,
+			'openWorldHint'   => false,
+		)
 		);
 
 		// Color palette consolidated tool (replaces list_color_palettes, create_color_palette, update_color_palette, delete_color_palette, add_color_to_palette, update_color_in_palette, delete_color_from_palette).
 		$this->register_tool(
 			'color_palette',
-			__( "Manage Bricks color palettes and colors.\n\nActions:\n- list: List all color palettes (no required params)\n- create: Create palette (requires: name; optional: colors)\n- update: Update palette (requires: palette_id; optional: name)\n- delete: Delete palette (requires: palette_id)\n- add_color: Add color to palette (requires: palette_id, color {light, name; optional: raw, parent, utility_classes}). 'hex' accepted as alias for 'light'\n- update_color: Update color in palette (requires: palette_id, color_id; optional fields in color: light, name, raw, parent_color_id, utility_classes). 'hex' accepted as alias for 'light'\n- delete_color: Remove color from palette (requires: palette_id, color_id)", 'bricks-mcp' ),
+			__( "Manage Bricks color palettes shown in the color picker. Colors can have CSS variable aliases (raw) and utility classes.\n\nWHEN: Use list to see existing palettes before adding colors. Use add_color with raw=var(--my-color) to link palette colors to CSS variables. Use hex as alias for light field.\n\nActions:\n- list: All palettes with colors\n- create: New palette (requires: name; optional: initial colors array)\n- update: Rename palette (requires: palette_id, name)\n- delete: Remove palette (requires: palette_id) — destructive\n- add_color: Add color (requires: palette_id, name, light/hex; optional: raw=CSS var, parent)\n- update_color: Modify color (requires: palette_id, color_id)\n- delete_color: Remove color (requires: palette_id, color_id)", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -1173,12 +1360,19 @@ $this->register_tool(
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_color_palette' )
+		,
+		array(
+			'readOnlyHint'    => false,
+			'destructiveHint' => true,
+			'idempotentHint'  => false,
+			'openWorldHint'   => false,
+		)
 		);
 
 		// Global variable consolidated tool (replaces list_global_variables, create_variable_category, update_variable_category, delete_variable_category, create_global_variable, update_global_variable, delete_global_variable, batch_create_global_variables).
 		$this->register_tool(
 			'global_variable',
-			__( "Manage Bricks global CSS variables.\n\nActions:\n- list: List all global variables (no required params)\n- create_category: Create variable category (requires: category_name)\n- update_category: Rename variable category (requires: category_id, category_name)\n- delete_category: Delete variable category (requires: category_id)\n- create: Create variable (requires: name, value; optional: category)\n- update: Update variable (requires: variable_id; optional: name, value, category)\n- delete: Delete variable (requires: variable_id)\n- batch_create: Create multiple variables (requires: variables)\n- batch_delete: Delete multiple variables (requires: variable_ids; max 50)\n- search: Search variables by name/value (optional: query, value_query, category_id)", 'bricks-mcp' ),
+			__( "Manage Bricks CSS custom properties (--variables) used in theme styles and element settings. Changes propagate sitewide instantly.\n\nWHEN: Use to define design tokens like spacing, font sizes, and brand colors. Use search to find variables before creating duplicates. Use batch_create to import a full design token set at once.\n\nActions:\n- list: List all variables with categories\n- search: Search by name or value (optional: query, value_query, category_id)\n- create: Create variable (requires: name, value; optional: category)\n- update: Update variable (requires: variable_id)\n- delete: Delete variable (requires: variable_id) — destructive\n- batch_create: Create many at once (requires: variables array)\n- batch_delete: Delete many at once (requires: variable_ids; max 50) — destructive\n- create_category / update_category / delete_category: Manage groupings", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -1232,12 +1426,18 @@ $this->register_tool(
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_global_variable' )
-		);
+		,
+array(
+'readOnlyHint'=>false,
+'destructiveHint'=>true,
+'idempotentHint'=>false,
+'openWorldHint'=>false,
+));
 
 		// Media consolidated tool (replaces search_unsplash, sideload_image, get_media_library, set_featured_image, remove_featured_image, get_image_element_settings).
 		$this->register_tool(
 			'media',
-			__( "Manage images and media library.\n\nActions:\n- search_unsplash: Search Unsplash photos (requires: query; optional: per_page)\n- sideload: Download image from URL to media library (requires: url; optional: filename, alt_text)\n- list: Browse media library (optional: per_page, page, mime_type)\n- set_featured: Set featured image on post (requires: post_id, attachment_id)\n- remove_featured: Remove featured image from post (requires: post_id)\n- get_image_settings: Get Bricks image element settings format (optional: target)", 'bricks-mcp' ),
+			__( "Search, upload, and assign images. Connects to Unsplash for free stock photos and WordPress media library.\n\nWHEN: Use search_unsplash then sideload to add stock photos to the media library. Use get_image_settings to get the correct Bricks format for image/background/gallery settings. Use set_featured to assign a post thumbnail.\n\nActions:\n- search_unsplash: Find stock photos (requires: query) — calls external API\n- sideload: Download URL into media library (requires: url; optional: filename, alt_text)\n- list: Browse media library (optional: per_page, mime_type)\n- set_featured: Set post thumbnail (requires: post_id, attachment_id)\n- remove_featured: Remove post thumbnail (requires: post_id)\n- get_image_settings: Get Bricks-format image object (requires: attachment_id, target=image|background|gallery)", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -1295,12 +1495,18 @@ $this->register_tool(
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_media' )
-		);
+		,
+array(
+'readOnlyHint'=>false,
+'destructiveHint'=>false,
+'idempotentHint'=>false,
+'openWorldHint'=>true,
+));
 
 		// Menu consolidated tool (replaces create_menu, update_menu, delete_menu, get_menu, list_menus, set_menu_items, assign_menu, unassign_menu, list_menu_locations).
 		$this->register_tool(
 			'menu',
-			__( "Manage WordPress navigation menus.\n\nActions:\n- list: List all menus (no required params)\n- get: Get menu with item tree (requires: menu_id)\n- create: Create menu (requires: name)\n- update: Rename menu (requires: menu_id, name)\n- delete: Delete menu permanently (requires: menu_id)\n- set_items: Replace all menu items (requires: menu_id, items)\n- assign: Assign menu to theme location (requires: menu_id, location)\n- unassign: Remove menu from location (requires: location)\n- list_locations: List available theme locations (no required params)", 'bricks-mcp' ),
+			__( "Create and manage WordPress navigation menus and assign them to theme locations. Use set_items to replace an entire menu tree in one call.\n\nWHEN: Use list then list_locations to see current assignments. Use set_items with a nested array to define the full menu structure at once. Use assign after creating a menu to make it appear in the header/footer nav element.\n\nActions:\n- list: All menus with item counts\n- get: Full menu with nested item tree (requires: menu_id)\n- create: New menu (requires: name)\n- update: Rename menu (requires: menu_id, name)\n- delete: Permanently delete menu (requires: menu_id) — destructive\n- set_items: Replace all items with new tree (requires: menu_id, items)\n- assign: Assign to theme location (requires: menu_id, location)\n- unassign: Remove from location (requires: location)\n- list_locations: Available theme locations with current assignments", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -1329,12 +1535,19 @@ $this->register_tool(
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_menu' )
+		,
+		array(
+			'readOnlyHint'    => false,
+			'destructiveHint' => true,
+			'idempotentHint'  => false,
+			'openWorldHint'   => false,
+		)
 		);
 
 		// Component consolidated tool (component definition CRUD + instance operations).
 		$this->register_tool(
 			'component',
-			__( "Manage Bricks Components (reusable element trees with properties and slots).\n\nActions:\n- list: List all component definitions (optional: category) [read]\n- get: Get full component definition (requires: component_id) [read]\n- create: Create component from element tree (requires: label, elements; optional: category, description, properties)\n- update: Update component definition (requires: component_id; optional: label, category, description, elements, properties)\n- delete: Delete component definition (requires: component_id)\n- instantiate: Place component instance on a page (requires: component_id, post_id; optional: parent_id, position, properties)\n- update_properties: Update instance property values (requires: post_id, instance_id, properties)\n- fill_slot: Fill a slot on a component instance with element content (requires: post_id, instance_id, slot_id, slot_elements)", 'bricks-mcp' ),
+			__( "Create and manage reusable Bricks components — element trees with configurable properties and content slots. Changes to a component definition propagate to all instances automatically.\n\nWHEN: Build a card, hero, or testimonial once as a component, then instantiate it on multiple pages. Use fill_slot to inject custom content into component placeholders. Use update_properties to change text/image per instance.\n\nActions:\n- list: List all components (optional: category)\n- get: Get full component definition (requires: component_id)\n- create: Build component from element tree (requires: label, elements)\n- update: Update definition — affects all instances (requires: component_id)\n- delete: Delete definition (requires: component_id) — instances render empty\n- instantiate: Place instance on a page (requires: component_id, post_id)\n- update_properties: Set per-instance property values (requires: post_id, instance_id, properties)\n- fill_slot: Inject content into a slot (requires: post_id, instance_id, slot_id, slot_elements)", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -1395,12 +1608,18 @@ $this->register_tool(
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_component' )
-		);
+		,
+array(
+'readOnlyHint'=>false,
+'destructiveHint'=>true,
+'idempotentHint'=>false,
+'openWorldHint'=>false,
+));
 
 		// WooCommerce consolidated tool (status, elements, dynamic tags, template scaffolding).
 		$this->register_tool(
 			'woocommerce',
-			__( "WooCommerce builder tools. Requires WooCommerce plugin active.\n\nActions:\n- status: Get WooCommerce status (version, page IDs, Bricks WooCommerce settings, available template types)\n- get_elements: List WooCommerce-specific Bricks elements (optional: category — product, cart, checkout, account, archive, utility)\n- get_dynamic_tags: Get WooCommerce dynamic data tags reference (optional: category — product_price, product_display, product_info, cart, order, post_compatible)\n- scaffold_template: Create a pre-populated WooCommerce template with standard elements (requires: template_type; optional: title, status)\n- scaffold_store: Create all essential WooCommerce templates at once (optional: types, skip_existing)", 'bricks-mcp' ),
+			__( "Build WooCommerce pages using Bricks. Requires WooCommerce active. Use scaffold_store to create all 8 required templates in one call.\n\nWHEN: Run woocommerce:status first to confirm WooCommerce is active. Use scaffold_store(skip_existing=true) to generate all templates without overwriting existing ones. Use get_elements to discover WooCommerce-specific Bricks elements. Use get_dynamic_tags for product data tag reference.\n\nActions:\n- status: WooCommerce version, page IDs, and Bricks WooCommerce settings\n- get_elements: WooCommerce-specific Bricks elements (optional: category=product|cart|checkout|account|archive)\n- get_dynamic_tags: Dynamic data tag reference (optional: category=product_price|product_display|cart|order)\n- scaffold_template: Create one pre-populated template (requires: template_type)\n- scaffold_store: Create all 8 WooCommerce templates at once (optional: types, skip_existing=true)", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -1439,12 +1658,19 @@ $this->register_tool(
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_woocommerce' )
+		,
+		array(
+			'readOnlyHint'    => false,
+			'destructiveHint' => false,
+			'idempotentHint'  => false,
+			'openWorldHint'   => false,
+		)
 		);
 
 		// Font management consolidated tool.
 		$this->register_tool(
 			'font',
-			__( "Manage Bricks font settings.\n\nActions:\n- get_status: Get font configuration overview (Google Fonts, Adobe Fonts, webfont loading)\n- get_adobe_fonts: List cached Adobe Fonts from your project\n- update_settings: Update font settings (optional: disable_google_fonts, webfont_loading, custom_fonts_preload)", 'bricks-mcp' ),
+			__( "Read and update Bricks font configuration including Google Fonts, Adobe Fonts, and webfont loading strategy.\n\nWHEN: Use get_status to audit current font setup. Use update_settings to disable Google Fonts for performance or set font-display strategy (swap is recommended for CLS). Use get_adobe_fonts to see Adobe Fonts project fonts.\n\nActions:\n- get_status: Font config overview (Google Fonts enabled, webfont loading, custom preload)\n- get_adobe_fonts: List cached Adobe Fonts\n- update_settings: Update font config (optional: disable_google_fonts, webfont_loading=swap|block|optional, custom_fonts_preload)", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -1470,12 +1696,19 @@ $this->register_tool(
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_font' )
+		,
+		array(
+			'readOnlyHint'    => false,
+			'destructiveHint' => false,
+			'idempotentHint'  => false,
+			'openWorldHint'   => false,
+		)
 		);
 
 		// Custom code consolidated tool.
 		$this->register_tool(
 			'code',
-			__( "Manage page-level custom CSS and JavaScript.\n\nActions:\n- get_page_css: Get page custom CSS and scripts (requires: post_id)\n- set_page_css: Set page custom CSS (requires: post_id, css)\n- get_page_scripts: Get page custom scripts only (requires: post_id)\n- set_page_scripts: Set page custom scripts (requires: post_id; optional: header, body_header, body_footer) [dangerous_actions required]", 'bricks-mcp' ),
+			__( "Read and write page-level custom CSS and JavaScript. Scripts require Dangerous Actions enabled in MCP settings.\n\nWHEN: Use set_page_css for page-specific overrides. Use set_page_scripts to inject GSAP, analytics, or other scripts into head/body. Always get first before setting to avoid overwriting existing code. Use code:get_page_css to check what CSS is already on a page.\n\nActions:\n- get_page_css: Read current custom CSS + scripts (requires: post_id)\n- set_page_css: Write/replace custom CSS (requires: post_id, css; empty string clears)\n- get_page_scripts: Read custom scripts only (requires: post_id)\n- set_page_scripts: Write scripts to head/body (requires: post_id; optional: header, body_header, body_footer) — requires Dangerous Actions enabled", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
@@ -1508,6 +1741,13 @@ $this->register_tool(
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_code' )
+		,
+		array(
+			'readOnlyHint'    => false,
+			'destructiveHint' => true,
+			'idempotentHint'  => false,
+			'openWorldHint'   => false,
+		)
 		);
 	}
 
@@ -1518,11 +1758,168 @@ $this->register_tool(
 	 *
 	 * @return \WP_Error|null WP_Error if Bricks required but not active, null if active.
 	 */
+		/**
+	 * Enrich a WP_Error with structured next-step guidance.
+	 *
+	 * Wraps the raw error in a structured array so AI clients get
+	 * actionable guidance alongside the error message.
+	 *
+	 * @param \WP_Error $error   The original error.
+	 * @param string    $hint    What the AI should do next.
+	 * @param string    $tool    Suggested tool to call next (optional).
+	 * @return \WP_Error The same error with enriched message.
+	 */
+		/**
+	 * Apply smart defaults to tool arguments to reduce required parameters.
+	 *
+	 * Injects sensible defaults so AI clients can call tools with fewer params.
+	 *
+	 * @param string               $tool_name Tool name.
+	 * @param array<string, mixed> $args      Raw arguments.
+	 * @return array<string, mixed> Arguments with defaults applied.
+	 */
+		/**
+	 * Apply minimal response format to strip verbose/redundant fields.
+	 *
+	 * When response_format=minimal is passed, removes large nested fields
+	 * that are rarely needed, reducing token usage by 40-60%.
+	 *
+	 * @param array<string, mixed> $result Full result array.
+	 * @return array<string, mixed> Slimmed result.
+	 */
+	private function apply_minimal_format( array $result ): array {
+		// Strip known verbose fields from common responses.
+		$strip_keys = [
+			'inputSchema',   // Tool schema definitions — large
+			'schemas',       // Element schemas — very large
+			'catalog',       // Full element catalog
+			'guide',         // Builder guide text
+			'content'        // Raw element arrays on list responses
+		];
+
+		foreach ( $strip_keys as $key ) {
+			if ( isset( $result[ $key ] ) && ( is_array( $result[ $key ] ) || strlen( (string) $result[ $key ] ) > 500 ) ) {
+				$result[ $key ] = '[omitted — use response_format=full to include]';
+			}
+		}
+
+		// For element arrays, return only IDs and names.
+		if ( isset( $result['elements'] ) && is_array( $result['elements'] ) ) {
+			$result['elements'] = array_map(
+				function( $el ) {
+					return [
+						'id'   => $el['id'] ?? null,
+						'name' => $el['name'] ?? null,
+					];
+				},
+				$result['elements']
+			);
+		}
+
+		// For templates list, strip element content.
+		if ( isset( $result['templates'] ) && is_array( $result['templates'] ) ) {
+			$result['templates'] = array_map(
+				function( $t ) {
+					unset( $t['elements'] );
+					return $t;
+				},
+				$result['templates']
+			);
+		}
+
+		$result['_format'] = 'minimal';
+		return $result;
+	}
+
+	private function apply_smart_defaults( string $tool_name, array $args ): array {
+		switch ( $tool_name ) {
+			case 'page':
+				// Default action to 'list' when omitted.
+				if ( ! isset( $args['action'] ) ) {
+					$args['action'] = 'list';
+				}
+				// Default view to 'visual' for get action (best for editing).
+				if ( isset( $args['action'] ) && 'get' === $args['action'] && ! isset( $args['view'] ) ) {
+					$args['view'] = 'summary';
+				}
+				// Default posts_per_page to 20 for list.
+				if ( isset( $args['action'] ) && 'list' === $args['action'] && ! isset( $args['posts_per_page'] ) ) {
+					$args['posts_per_page'] = 20;
+				}
+				// Default status to 'any' for list so drafts are included.
+				if ( isset( $args['action'] ) && 'list' === $args['action'] && ! isset( $args['status'] ) ) {
+					$args['status'] = 'any';
+				}
+				break;
+
+			case 'bricks':
+				// Default action to 'get_settings'.
+				if ( ! isset( $args['action'] ) ) {
+					$args['action'] = 'get_settings';
+				}
+				// Default get_element_schemas to catalog_only=true to reduce response size.
+				if ( isset( $args['action'] ) && 'get_element_schemas' === $args['action'] && ! isset( $args['catalog_only'] ) && ! isset( $args['element'] ) ) {
+					$args['catalog_only'] = true;
+				}
+				break;
+
+			case 'element':
+				// Default parent_id to '0' (root) for add action.
+				if ( isset( $args['action'] ) && 'add' === $args['action'] && ! isset( $args['parent_id'] ) ) {
+					$args['parent_id'] = '0';
+				}
+				break;
+
+			case 'template':
+				// Default status to 'publish' for create.
+				if ( isset( $args['action'] ) && 'create' === $args['action'] && ! isset( $args['status'] ) ) {
+					$args['status'] = 'publish';
+				}
+				// Default list to show all statuses.
+				if ( isset( $args['action'] ) && 'list' === $args['action'] && ! isset( $args['status'] ) ) {
+					$args['status'] = 'publish';
+				}
+				break;
+
+			case 'wordpress':
+				// Default posts_per_page to 20.
+				if ( isset( $args['action'] ) && 'get_posts' === $args['action'] && ! isset( $args['posts_per_page'] ) ) {
+					$args['posts_per_page'] = 20;
+				}
+				break;
+
+			case 'global_class':
+				// Default replace_styles to false (merge, not replace).
+				if ( isset( $args['action'] ) && 'update' === $args['action'] && ! isset( $args['replace_styles'] ) ) {
+					$args['replace_styles'] = false;
+				}
+				break;
+		}
+
+		return $args;
+	}
+
+	private function enrich_error( \WP_Error $error, string $hint = '', string $tool = '' ): \WP_Error {
+		$data = array(
+			'error'      => $error->get_error_code(),
+			'message'    => $error->get_error_message(),
+		);
+		if ( ! empty( $hint ) ) {
+			$data['next_step'] = $hint;
+		}
+		if ( ! empty( $tool ) ) {
+			$data['suggested_tool'] = $tool;
+		}
+		$error->add_data( $data );
+		return $error;
+	}
+
 	private function require_bricks(): ?\WP_Error {
 		if ( ! $this->bricks_service->is_bricks_active() ) {
 			return new \WP_Error(
 				'bricks_required',
-				__( 'Bricks Builder must be installed and active to use this tool. Install and activate Bricks Builder, then retry.', 'bricks-mcp' )
+				__( 'Bricks Builder must be installed and active. Install and activate it, then retry.', 'bricks-mcp' ),
+				[ 'next_step' => 'Install Bricks Builder from Plugins > Add New, activate it, then retry this tool.', 'suggested_tool' => 'get_site_info' ]
 			);
 		}
 		return null;
@@ -3213,7 +3610,7 @@ $this->register_tool(
 		}
 
 		if ( empty( $args['post_id'] ) ) {
-			return new \WP_Error( 'missing_post_id', __( 'post_id is required. Use list_pages to find valid post IDs.', 'bricks-mcp' ) );
+			return new \WP_Error( 'missing_post_id', __( 'post_id is required.', 'bricks-mcp' ), [ 'next_step' => 'Call page:list to find valid post IDs.', 'suggested_tool' => 'page' ] );
 		}
 
 		$post_id = (int) $args['post_id'];
@@ -3222,19 +3619,16 @@ $this->register_tool(
 		if ( ! $post ) {
 			return new \WP_Error(
 				'post_not_found',
-				/* translators: %d: Post ID */
-				sprintf( __( 'Post %d not found. Use list_pages to find valid post IDs.', 'bricks-mcp' ), $post_id )
+				sprintf( __( 'Post %d not found.', 'bricks-mcp' ), $post_id ),
+				[ 'next_step' => 'Call page:list to find valid post IDs.', 'suggested_tool' => 'page' ]
 			);
 		}
 
 		if ( ! $this->bricks_service->is_bricks_page( $post_id ) ) {
 			return new \WP_Error(
 				'not_bricks_page',
-				sprintf(
-					/* translators: %d: Post ID */
-					__( 'Post %d is not using the Bricks editor. Use the enable_bricks tool to enable Bricks on this post first.', 'bricks-mcp' ),
-					$post_id
-				)
+				sprintf( __( 'Post %d is not using the Bricks editor.', 'bricks-mcp' ), $post_id ),
+				[ 'next_step' => 'Call bricks:enable(post_id=' . $post_id . ') to enable Bricks on this post first.', 'suggested_tool' => 'bricks' ]
 			);
 		}
 
@@ -9362,12 +9756,6 @@ $this->register_tool(
 		);
 	}
 	
-	/**
-	 * Tool: Diagnose a Bricks page for known issues before editing.
-	 *
-	 * @param array<string, mixed> $args Tool arguments.
-	 * @return array<string, mixed>|\WP_Error Diagnosis report or error.
-	 */
 	public function tool_page_diagnose( array $args ): array|\WP_Error {
 		$bricks_error = $this->require_bricks();
 		if ( null !== $bricks_error ) {
@@ -9375,194 +9763,24 @@ $this->register_tool(
 		}
 
 		if ( empty( $args['post_id'] ) ) {
-			return new \WP_Error( 'missing_post_id', __( 'post_id is required.', 'bricks-mcp' ) );
+			return new \WP_Error(
+				'missing_post_id',
+				__( 'post_id is required.', 'bricks-mcp' ),
+				array( 'next_step' => 'Call page:list to find valid post IDs.', 'suggested_tool' => 'page' )
+			);
 		}
 
 		$post_id = (int) $args['post_id'];
 		$post    = get_post( $post_id );
 
 		if ( ! $post ) {
-			return new \WP_Error( 'post_not_found', sprintf( __( 'Post %d not found.', 'bricks-mcp' ), $post_id ) );
+			return new \WP_Error(
+				'post_not_found',
+				sprintf( __( 'Post %d not found.', 'bricks-mcp' ), $post_id ),
+				array( 'next_step' => 'Call page:list to find valid post IDs.', 'suggested_tool' => 'page' )
+			);
 		}
 
-		$elements = $this->bricks_service->get_elements( $post_id );
-		$issues   = array();
-
-		$id_map = array();
-		foreach ( $elements as $el ) {
-			$id_map[ $el['id'] ] = true;
-		}
-
-		$global_classes   = $this->bricks_service->get_global_classes();
-		$global_class_ids = array();
-		foreach ( $global_classes as $gc ) {
-			$global_class_ids[ $gc['id'] ?? '' ] = true;
-		}
-
-		$template_type    = get_post_meta( $post_id, '_bricks_template_type', true );
-		$is_header_footer = in_array( $template_type, array( 'header', 'footer' ), true );
-
-		if ( $is_header_footer ) {
-			$phantom = get_post_meta( $post_id, '_bricks_page_content_2', true );
-			if ( ! empty( $phantom ) ) {
-				$issues[] = array(
-					'element_id' => null,
-					'severity'   => 'error',
-					'type'       => 'phantom_content',
-					'message'    => ucfirst( $template_type ) . ' template has phantom _bricks_page_content_2 that renders a ghost section below the real template.',
-					'fix'        => 'Run: delete_post_meta( ' . $post_id . ", '_bricks_page_content_2' )",
-				);
-			}
-		}
-
-		$valid_bps = array( 'tablet_landscape', 'tablet_portrait', 'mobile_landscape', 'mobile_portrait' );
-
-		foreach ( $elements as $el ) {
-			$el_id    = $el['id'] ?? 'unknown';
-			$el_name  = $el['name'] ?? 'unknown';
-			$settings = $el['settings'] ?? array();
-
-			foreach ( array( 'customScriptsBodyFooter', 'customScriptsBodyHeader', 'customScriptsHeader' ) as $sf ) {
-				if ( ! empty( $settings[ $sf ] ) && strpos( $settings[ $sf ], '<script' ) === false ) {
-					$issues[] = array(
-						'element_id' => $el_id,
-						'severity'   => 'error',
-						'type'       => 'script_missing_tags',
-						'message'    => "Element {$el_id} ({$el_name}): {$sf} has JS without <script> tags - will print as visible text.",
-						'fix'        => 'Wrap the content in <script>...</script> tags.',
-					);
-				}
-			}
-
-			if ( 'code' === $el_name && ! empty( $settings['code'] ) && strpos( $settings['code'], '<?php' ) !== false && empty( $settings['executeCode'] ) ) {
-				$issues[] = array(
-					'element_id' => $el_id,
-					'severity'   => 'warning',
-					'type'       => 'php_execute_disabled',
-					'message'    => "Element {$el_id}: code element contains PHP but executeCode is not enabled.",
-					'fix'        => 'Set settings.executeCode = true on this element.',
-				);
-			}
-
-			if ( ! empty( $settings['_cssCustom'] ) && strpos( $settings['_cssCustom'], '%root%' ) !== false ) {
-				$issues[] = array(
-					'element_id' => $el_id,
-					'severity'   => 'error',
-					'type'       => 'root_placeholder',
-					'message'    => "Element {$el_id} ({$el_name}): _cssCustom uses %root% which only works in the visual editor, not via API.",
-					'fix'        => "Replace %root% with #brxe-{$el_id}",
-				);
-			}
-
-			if ( array_key_exists( '_maxWidth', $settings ) ) {
-				$issues[] = array(
-					'element_id' => $el_id,
-					'severity'   => 'error',
-					'type'       => 'wrong_key_maxwidth',
-					'message'    => "Element {$el_id} ({$el_name}): uses _maxWidth which is silently ignored.",
-					'fix'        => 'Rename _maxWidth to _widthMax.',
-				);
-			}
-
-			foreach ( array( '_background', 'color', 'iconColor' ) as $ck ) {
-				if ( isset( $settings[ $ck ] ) && is_string( $settings[ $ck ] ) && preg_match( '/^#[0-9a-fA-F]{3,8}$/', $settings[ $ck ] ) ) {
-					$issues[] = array(
-						'element_id' => $el_id,
-						'severity'   => 'warning',
-						'type'       => 'plain_string_color',
-						'message'    => "Element {$el_id} ({$el_name}): {$ck} is a plain hex string. Bricks expects {\"hex\":\"#value\"} objects.",
-						'fix'        => "Change {$ck} to {\"hex\":\"{$settings[$ck]}\"}.",
-					);
-				}
-			}
-
-			foreach ( array_keys( $settings ) as $key ) {
-    if ( strpos( $key, ':' ) !== false ) {
-        $bp = explode( ':', $key, 2 )[1] ?? '';
-        // Skip pseudo states — they are not breakpoints.
-        $valid_pseudo = array( 'hover', 'focus', 'active', 'visited', 'placeholder', 'before', 'after' );
-        if ( in_array( $bp, $valid_pseudo, true ) ) {
-            continue;
-        }
-        if ( ! empty( $bp ) && ! in_array( $bp, $valid_bps, true ) ) {
-            $issues[] = array(
-                'element_id' => $el_id,
-                'severity'   => 'warning',
-                'type'       => 'invalid_breakpoint',
-                'message'    => "Element {$el_id}: setting key '{$key}' uses unknown breakpoint '{$bp}'.",
-                'fix'        => 'Valid breakpoints: tablet_landscape, tablet_portrait, mobile_landscape, mobile_portrait.',
-            );
-        }
-    }
-}
-			foreach ( ( $el['children'] ?? array() ) as $child_id ) {
-				if ( ! isset( $id_map[ $child_id ] ) ) {
-					$issues[] = array(
-						'element_id' => $el_id,
-						'severity'   => 'error',
-						'type'       => 'orphaned_child',
-						'message'    => "Element {$el_id}: child ID '{$child_id}' does not exist in the page.",
-						'fix'        => "Remove '{$child_id}' from element {$el_id} children array.",
-					);
-				}
-			}
-
-			if ( ! empty( $settings['_cssClasses'] ) ) {
-				$used = is_array( $settings['_cssClasses'] ) ? $settings['_cssClasses'] : explode( ' ', $settings['_cssClasses'] );
-				foreach ( $used as $cid ) {
-					$cid = trim( $cid );
-					if ( ! empty( $cid ) && ! isset( $global_class_ids[ $cid ] ) ) {
-						$issues[] = array(
-							'element_id' => $el_id,
-							'severity'   => 'warning',
-							'type'       => 'missing_global_class',
-							'message'    => "Element {$el_id}: references global class '{$cid}' which does not exist.",
-							'fix'        => 'Create the class via global_class:create or remove the reference.',
-						);
-					}
-				}
-			}
-
-			if ( ! empty( $settings['_border'] ) && is_array( $settings['_border'] ) ) {
-				if ( isset( $settings['_border']['width'] ) && is_int( $settings['_border']['width'] ) ) {
-					$w        = $settings['_border']['width'];
-					$issues[] = array(
-						'element_id' => $el_id,
-						'severity'   => 'warning',
-						'type'       => 'integer_border',
-						'message'    => "Element {$el_id}: _border.width is integer {$w}, Bricks expects a CSS string like '{$w}px'.",
-						'fix'        => "Change _border.width from {$w} to '{$w}px'.",
-					);
-				}
-				if ( ! empty( $settings['_border']['radius'] ) && is_array( $settings['_border']['radius'] ) ) {
-					foreach ( $settings['_border']['radius'] as $side => $val ) {
-						if ( is_int( $val ) ) {
-							$issues[] = array(
-								'element_id' => $el_id,
-								'severity'   => 'warning',
-								'type'       => 'integer_border_radius',
-								'message'    => "Element {$el_id}: _border.radius.{$side} is integer {$val}, expects CSS string like '{$val}px'.",
-								'fix'        => "Change _border.radius.{$side} from {$val} to '{$val}px'.",
-							);
-							break;
-						}
-					}
-				}
-			}
-		}
-
-		$errors   = count( array_filter( $issues, fn( $i ) => 'error' === $i['severity'] ) );
-		$warnings = count( array_filter( $issues, fn( $i ) => 'warning' === $i['severity'] ) );
-
-		return array(
-			'post_id'       => $post_id,
-			'title'         => $post->post_title,
-			'element_count' => count( $elements ),
-			'issue_count'   => count( $issues ),
-			'error_count'   => $errors,
-			'warning_count' => $warnings,
-			'status'        => 0 === count( $issues ) ? 'clean' : ( $errors > 0 ? 'errors' : 'warnings' ),
-			'issues'        => $issues,
-		);
+		return $this->bricks_service->diagnose_page( $post_id );
 	}
 }

--- a/includes/MCP/Router.php
+++ b/includes/MCP/Router.php
@@ -38,38 +38,9 @@ final class Router {
 	private const COMPONENTS_OPTION = 'bricks_components';
 
 	/**
-	 * Tool names exposed to MCP clients in tools/list.
-	 *
-	 * Hidden legacy tools remain callable through execute_tool() alias shims.
-	 *
-	 * @var array<int, string>
-	 */
-	private const VISIBLE_TOOL_NAMES = array(
-		'get_site_info',
-		'get_builder_guide',
-		'bricks',
-		'content',
-		'template',
-		'design',
-		'media',
-		'menu',
-		'component',
-		'woocommerce',
-		'code',
-	);
-
-	/**
 	 * Registered tools.
 	 *
-	 * @var array<string, array{
-	 *     name: string,
-	 *     description: string,
-	 *     inputSchema: array,
-	 *     handler: callable,
-	 *     annotations?: array<string, mixed>,
-	 *     outputSchema?: array<string, mixed>,
-	 *     defaults?: array<string, mixed>
-	 * }>
+	 * @var array<string, array{name: string, description: string, inputSchema: array, handler: callable}>
 	 */
 	private array $tools = array();
 
@@ -219,13 +190,6 @@ final class Router {
 			array( $this, 'tool_wordpress' )
 		);
 
-		$this->register_tool(
-			'content',
-			__( 'Manage WordPress and Bricks content for a given site; requires an action and validates target-specific inputs.', 'bricks-mcp' ),
-			$this->get_content_tool_schema(),
-			array( $this, 'tool_content' )
-		);
-
 		/**
 		 * Filter the registered MCP tools.
 		 *
@@ -239,548 +203,18 @@ final class Router {
 	/**
 	 * Register a tool.
 	 *
-	 * @param string               $name          Tool name.
-	 * @param string               $description   Tool description.
-	 * @param array<string, mixed> $input_schema  Tool input schema.
-	 * @param callable             $handler       Tool handler callback.
-	 * @param array<string, mixed> $annotations   Optional MCP tool annotations.
-	 * @param array<string, mixed> $output_schema Optional MCP output schema.
-	 * @param array<string, mixed> $defaults      Optional smart defaults metadata.
+	 * @param string   $name             Tool name.
+	 * @param string   $description      Tool description.
+	 * @param array    $input_schema     Tool input schema.
+	 * @param callable $handler          Tool handler callback.
 	 * @return void
 	 */
-	public function register_tool(
-		string $name,
-		string $description,
-		array $input_schema,
-		callable $handler,
-		array $annotations = array(),
-		array $output_schema = array(),
-		array $defaults = array()
-	): void {
-		$description   = $this->get_normalized_tool_description( $name, $description );
-		$input_schema  = $this->inject_response_format_property( $input_schema );
-
-		// Auto-populate v2.0 metadata when callers use the legacy 4-arg signature.
-		// This ensures every tool exposes annotations, outputSchema, and defaults
-		// without requiring existing `bricks_mcp_tools` filter callbacks to change.
-		$annotations   = array() === $annotations ? $this->get_default_tool_annotations( $name ) : $annotations;
-		$output_schema = array() === $output_schema ? $this->get_default_tool_output_schema( $name ) : $output_schema;
-		$defaults      = array() === $defaults ? $this->get_default_tool_defaults( $name ) : $defaults;
-
-		$tool = array(
+	public function register_tool( string $name, string $description, array $input_schema, callable $handler ): void {
+		$this->tools[ $name ] = array(
 			'name'        => $name,
 			'description' => $description,
 			'inputSchema' => $input_schema,
 			'handler'     => $handler,
-		);
-
-		if ( array() !== $annotations ) {
-			$tool['annotations'] = $annotations;
-		}
-
-		if ( array() !== $output_schema ) {
-			$tool['outputSchema'] = $output_schema;
-		}
-
-		if ( array() !== $defaults ) {
-			$tool['defaults'] = $defaults;
-		}
-
-		$this->tools[ $name ] = $tool;
-	}
-
-	/**
-	 * Get the Bricks service for protocol registries.
-	 *
-	 * @return BricksService
-	 */
-	public function get_bricks_service(): BricksService {
-		return $this->bricks_service;
-	}
-
-	/**
-	 * Inject response_format into a tool schema.
-	 *
-	 * @param array<string, mixed> $input_schema Tool input schema.
-	 * @return array<string, mixed>
-	 */
-	private function inject_response_format_property( array $input_schema ): array {
-		$properties = $input_schema['properties'] ?? array();
-
-		if ( ! is_array( $properties ) || isset( $properties['response_format'] ) ) {
-			return $input_schema;
-		}
-
-		$properties['response_format'] = array(
-			'type'        => 'string',
-			'enum'        => array( 'verbose', 'compact' ),
-			'description' => __( 'Response verbosity. Use verbose for full detail or compact to omit empty fields and reduce token usage.', 'bricks-mcp' ),
-		);
-
-		$input_schema['properties'] = $properties;
-
-		return $input_schema;
-	}
-
-	/**
-	 * Build default annotations for a tool.
-	 *
-	 * @param string $name Tool name.
-	 * @return array<string, bool>
-	 */
-	private function get_default_tool_annotations( string $name ): array {
-		$read_only_tools = array(
-			'get_site_info',
-			'get_builder_guide',
-			'wordpress',
-		);
-
-		$destructive_tools = array(
-			'bricks',
-			'content',
-			'page',
-			'element',
-			'template',
-			'template_taxonomy',
-			'global_class',
-			'theme_style',
-			'typography_scale',
-			'color_palette',
-			'global_variable',
-			'menu',
-			'component',
-			'design',
-		);
-
-		$open_world_tools = array(
-			'media',
-			'template',
-		);
-
-		return array(
-			'readOnlyHint'    => in_array( $name, $read_only_tools, true ),
-			'destructiveHint' => in_array( $name, $destructive_tools, true ),
-			'idempotentHint'  => in_array( $name, $read_only_tools, true ),
-			'openWorldHint'   => in_array( $name, $open_world_tools, true ),
-		);
-	}
-
-	/**
-	 * Build default output schema for a tool.
-	 *
-	 * @param string $name Tool name.
-	 * @return array<string, mixed>
-	 */
-	private function get_default_tool_output_schema( string $name ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
-		return array(
-			'type'                 => 'object',
-			'additionalProperties' => true,
-		);
-	}
-
-	/**
-	 * Build default smart-default metadata for a tool.
-	 *
-	 * @param string $name Tool name.
-	 * @return array<string, mixed>
-	 */
-	private function get_default_tool_defaults( string $name ): array {
-		return match ( $name ) {
-			'wordpress' => array(
-				'get_posts' => array(
-					'post_type'      => 'post',
-					'posts_per_page' => 10,
-					'orderby'        => 'date',
-					'order'          => 'DESC',
-					'post_status'    => 'publish',
-				),
-				'get_users' => array(
-					'number' => 10,
-				),
-				'get_plugins' => array(
-					'status' => 'all',
-				),
-			),
-			'content' => array(
-				'list' => array(
-					'post_type'      => 'page',
-					'status'         => 'any',
-					'posts_per_page' => 20,
-					'paged'          => 1,
-					'bricks_only'    => true,
-				),
-				'get_posts' => array(
-					'post_type'      => 'post',
-					'posts_per_page' => 10,
-					'orderby'        => 'date',
-					'order'          => 'DESC',
-					'post_status'    => 'publish',
-				),
-			),
-			'page' => array(
-				'list' => array(
-					'post_type'      => 'page',
-					'status'         => 'any',
-					'posts_per_page' => 20,
-					'paged'          => 1,
-					'bricks_only'    => true,
-				),
-			),
-			'bricks' => array(
-				'get_settings' => array(
-					'category' => 'general',
-				),
-			),
-			'template' => array(
-				'list' => array(
-					'status' => 'publish',
-				),
-			),
-			'media' => array(
-				'list' => array(
-					'per_page' => 20,
-					'page'     => 1,
-				),
-			),
-			default => array(),
-		};
-	}
-
-	/**
-	 * Normalize tool descriptions to the action + target + constraint format.
-	 *
-	 * @param string $name        Tool name.
-	 * @param string $description Existing description.
-	 * @return string
-	 */
-	private function get_normalized_tool_description( string $name, string $description ): string {
-		return match ( $name ) {
-			'get_site_info'      => 'Read WordPress site details for the current installation; optionally runs diagnostics for connection health.',
-			'get_builder_guide'  => 'Read the Bricks builder guide for the current site; use it before editing Bricks content.',
-			'bricks'             => 'Manage Bricks builder settings and schema for the current site; requires an action scoped to builder data.',
-			'content'            => 'Manage WordPress and Bricks content for a given site; requires an action and validates target-specific inputs.',
-			'template'           => 'Manage Bricks templates and targeting rules for a given site; requires an action and validates template-specific inputs.',
-			'design'             => 'Manage Bricks design tokens and style systems for a given site; requires a design domain and an action.',
-			'media'              => 'Manage media assets for the current site; requires an action and validates upload or library constraints.',
-			'menu'               => 'Manage WordPress navigation menus for the current site; requires an action and a menu target when writing.',
-			'component'          => 'Manage Bricks components for the current site; requires an action and component-specific identifiers when writing.',
-			'woocommerce'        => 'Manage WooCommerce builder data for the current site; requires WooCommerce to be active and an action.',
-			'code'               => 'Manage page-level custom CSS and scripts for a given post; requires an action and a post ID.',
-			'wordpress'          => 'Read WordPress core data for the current site; requires a read-only action scoped to posts, users, or plugins.',
-			'page'               => 'Manage Bricks pages for the current site; requires an action and a page target when writing.',
-			'element'            => 'Manage Bricks elements for a given page; requires an action and explicit element identifiers when writing.',
-			'template_condition' => 'Manage Bricks template targeting rules for the current site; requires an action and template condition data.',
-			'template_taxonomy'  => 'Manage Bricks template tags and bundles for the current site; requires an action and taxonomy-specific identifiers when writing.',
-			'global_class'       => 'Manage Bricks global classes for the current site; requires an action and explicit class identifiers when writing.',
-			'theme_style'        => 'Manage Bricks theme styles for the current site; requires an action and explicit style identifiers when writing.',
-			'typography_scale'   => 'Manage Bricks typography scales for the current site; requires an action and explicit scale identifiers when writing.',
-			'color_palette'      => 'Manage Bricks color palettes for the current site; requires an action and explicit palette identifiers when writing.',
-			'global_variable'    => 'Manage Bricks global variables for the current site; requires an action and explicit variable identifiers when writing.',
-			'font'               => 'Manage Bricks font settings for the current site; requires an action and updates only explicit font options.',
-			default              => $description,
-		};
-	}
-
-	/**
-	 * Resolve alias tool calls to canonical tool names and arguments.
-	 *
-	 * @param string               $name      Requested tool name.
-	 * @param array<string, mixed> $arguments Tool arguments.
-	 * @return array{name: string, arguments: array<string, mixed>}|\WP_Error
-	 */
-	private function resolve_tool_call( string $name, array $arguments ): array|\WP_Error {
-		$aliases = $this->get_tool_aliases();
-
-		if ( isset( $this->tools[ $name ] ) ) {
-			return array(
-				'name'      => $name,
-				'arguments' => $arguments,
-			);
-		}
-
-		if ( ! isset( $aliases[ $name ] ) ) {
-			return new \WP_Error(
-				'unknown_tool',
-				sprintf(
-					/* translators: %s: Tool name */
-					__( 'Unknown tool: %s', 'bricks-mcp' ),
-					$name
-				)
-			);
-		}
-
-		$alias_arguments = $aliases[ $name ]['arguments'] ?? array();
-
-		return array(
-			'name'      => $aliases[ $name ]['name'],
-			'arguments' => array_merge( $alias_arguments, $arguments ),
-		);
-	}
-
-	/**
-	 * Format a tool result according to response_format.
-	 *
-	 * @param string               $name            Tool name.
-	 * @param array<string, mixed>|string $result   Raw result.
-	 * @param mixed                $response_format Requested response format.
-	 * @return array<string, mixed>|string
-	 */
-	private function format_tool_result( string $name, array|string $result, mixed $response_format ): array|string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
-		if ( 'compact' !== $response_format || ! is_array( $result ) ) {
-			return $result;
-		}
-
-		return $this->trim_compact_result( $result );
-	}
-
-	/**
-	 * Recursively trim null and empty collection values for compact responses.
-	 *
-	 * @param mixed $value Value to trim.
-	 * @return mixed
-	 */
-	private function trim_compact_result( mixed $value ): mixed {
-		if ( ! is_array( $value ) ) {
-			return $value;
-		}
-
-		if ( array() === $value ) {
-			return array();
-		}
-
-		$is_list = array_keys( $value ) === range( 0, count( $value ) - 1 );
-		$trimmed = array();
-
-		foreach ( $value as $key => $item ) {
-			$normalized = $this->trim_compact_result( $item );
-
-			if ( null === $normalized ) {
-				continue;
-			}
-
-			if ( is_array( $normalized ) && array() === $normalized ) {
-				continue;
-			}
-
-			$trimmed[ $key ] = $normalized;
-		}
-
-		return $is_list ? array_values( $trimmed ) : $trimmed;
-	}
-
-	/**
-	 * Schema for the consolidated content tool.
-	 *
-	 * @return array<string, mixed>
-	 */
-	private function get_content_tool_schema(): array {
-		return array(
-			'type'       => 'object',
-			'properties' => array(
-				'action'         => array(
-					'type'        => 'string',
-					'enum'        => array( 'get_posts', 'get_post', 'get_users', 'get_plugins', 'list', 'search', 'get', 'create', 'update_content', 'update_meta', 'delete', 'duplicate', 'get_settings', 'update_settings', 'get_seo', 'update_seo', 'add', 'update', 'remove', 'get_conditions', 'set_conditions', 'move', 'bulk_update' ),
-					'description' => __( 'Action to perform.', 'bricks-mcp' ),
-				),
-				'post_id'        => array( 'type' => 'integer' ),
-				'post_type'      => array( 'type' => 'string' ),
-				'posts_per_page' => array( 'type' => 'integer' ),
-				'paged'          => array( 'type' => 'integer' ),
-				'orderby'        => array( 'type' => 'string' ),
-				'order'          => array( 'type' => 'string', 'enum' => array( 'ASC', 'DESC' ) ),
-				'status'         => array( 'type' => 'string' ),
-				'role'           => array( 'type' => 'string' ),
-				'number'         => array( 'type' => 'integer' ),
-				'id'             => array( 'type' => 'integer' ),
-				'include_pii'    => array( 'type' => 'boolean' ),
-				'bricks_only'    => array( 'type' => 'boolean' ),
-				'search'         => array( 'type' => 'string' ),
-				'view'           => array( 'type' => 'string', 'enum' => array( 'detail', 'summary' ) ),
-				'title'          => array( 'type' => 'string' ),
-				'elements'       => array( 'type' => 'array' ),
-				'slug'           => array( 'type' => 'string' ),
-				'settings'       => array( 'type' => 'object' ),
-				'description'    => array( 'type' => 'string' ),
-				'robots_noindex' => array( 'type' => 'boolean' ),
-				'robots_nofollow' => array( 'type' => 'boolean' ),
-				'canonical'      => array( 'type' => 'string' ),
-				'og_title'       => array( 'type' => 'string' ),
-				'og_description' => array( 'type' => 'string' ),
-				'og_image'       => array( 'type' => 'string' ),
-				'twitter_title'  => array( 'type' => 'string' ),
-				'twitter_description' => array( 'type' => 'string' ),
-				'twitter_image'  => array( 'type' => 'string' ),
-				'focus_keyword'  => array( 'type' => 'string' ),
-				'element'        => array( 'type' => 'object' ),
-				'name'           => array( 'type' => 'string' ),
-				'element_id'     => array( 'type' => 'string' ),
-				'position'       => array( 'type' => 'integer' ),
-				'parent_id'      => array( 'type' => 'string' ),
-				'conditions'     => array( 'type' => 'array' ),
-				'target_parent_id' => array( 'type' => 'string' ),
-				'updates'        => array( 'type' => 'array' ),
-			),
-			'required'   => array( 'action' ),
-		);
-	}
-
-	/**
-	 * Schema for the consolidated design tool.
-	 *
-	 * @return array<string, mixed>
-	 */
-	private function get_design_tool_schema(): array {
-		return array(
-			'type'       => 'object',
-			'properties' => array(
-				'action'      => array(
-					'type'        => 'string',
-					'enum'        => array( 'list', 'get', 'create', 'update', 'delete', 'apply', 'remove', 'batch_create', 'batch_delete', 'import_css', 'list_categories', 'create_category', 'update_category', 'delete_category', 'export', 'import_json', 'add_color', 'update_color', 'delete_color', 'search', 'get_status', 'get_adobe_fonts', 'update_settings' ),
-					'description' => __( 'Action to perform.', 'bricks-mcp' ),
-				),
-				'domain'      => array(
-					'type'        => 'string',
-					'enum'        => array( 'global_class', 'theme_style', 'typography_scale', 'color_palette', 'global_variable', 'font' ),
-					'description' => __( 'Design subsystem to target.', 'bricks-mcp' ),
-				),
-				'class_name'  => array( 'type' => 'string' ),
-				'name'        => array( 'type' => 'string' ),
-				'styles'      => array( 'type' => 'object' ),
-				'color'       => array( 'type' => 'object' ),
-				'category'    => array( 'type' => 'string' ),
-				'post_id'     => array( 'type' => 'integer' ),
-				'element_ids' => array( 'type' => 'array' ),
-				'classes'     => array( 'type' => 'array' ),
-				'css'         => array( 'type' => 'string' ),
-				'category_name' => array( 'type' => 'string' ),
-				'category_id' => array( 'type' => 'string' ),
-				'search'      => array( 'type' => 'string' ),
-				'classes_data' => array( 'type' => 'object' ),
-				'style_id'    => array( 'type' => 'string' ),
-				'conditions'  => array( 'type' => 'array' ),
-				'active'      => array( 'type' => 'boolean' ),
-				'replace_section' => array( 'type' => 'boolean' ),
-				'hard_delete' => array( 'type' => 'boolean' ),
-				'scale_id'    => array( 'type' => 'string' ),
-				'palette_id'  => array( 'type' => 'string' ),
-				'colors'      => array( 'type' => 'array' ),
-				'color_id'    => array( 'type' => 'string' ),
-				'variable_id' => array( 'type' => 'string' ),
-				'value'       => array( 'type' => 'string' ),
-				'variables'   => array( 'type' => 'array' ),
-				'variable_ids' => array( 'type' => 'array' ),
-				'value_query' => array( 'type' => 'string' ),
-				'disable_google_fonts' => array( 'type' => 'boolean' ),
-				'webfont_loading' => array( 'type' => 'string' ),
-				'custom_fonts_preload' => array( 'type' => 'boolean' ),
-			),
-			'required'   => array( 'action', 'domain' ),
-		);
-	}
-
-	/**
-	 * Get alias map for legacy and hidden tool names.
-	 *
-	 * @return array<string, array{name: string, arguments: array<string, mixed>}>
-	 */
-	private function get_tool_aliases(): array {
-		return array(
-			'wordpress'              => array( 'name' => 'content', 'arguments' => array() ),
-			'page'                   => array( 'name' => 'content', 'arguments' => array() ),
-			'element'                => array( 'name' => 'content', 'arguments' => array() ),
-			'template_condition'     => array( 'name' => 'template', 'arguments' => array() ),
-			'template_taxonomy'      => array( 'name' => 'template', 'arguments' => array() ),
-			'global_class'           => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_class' ) ),
-			'theme_style'            => array( 'name' => 'design', 'arguments' => array( 'domain' => 'theme_style' ) ),
-			'typography_scale'       => array( 'name' => 'design', 'arguments' => array( 'domain' => 'typography_scale' ) ),
-			'color_palette'          => array( 'name' => 'design', 'arguments' => array( 'domain' => 'color_palette' ) ),
-			'global_variable'        => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_variable' ) ),
-			'font'                   => array( 'name' => 'design', 'arguments' => array( 'domain' => 'font' ) ),
-			'get_posts'              => array( 'name' => 'content', 'arguments' => array( 'action' => 'get_posts' ) ),
-			'get_post'               => array( 'name' => 'content', 'arguments' => array( 'action' => 'get_post' ) ),
-			'get_users'              => array( 'name' => 'content', 'arguments' => array( 'action' => 'get_users' ) ),
-			'get_plugins'            => array( 'name' => 'content', 'arguments' => array( 'action' => 'get_plugins' ) ),
-			'list_pages'             => array( 'name' => 'content', 'arguments' => array( 'action' => 'list' ) ),
-			'search_pages'           => array( 'name' => 'content', 'arguments' => array( 'action' => 'search' ) ),
-			'get_bricks_content'     => array( 'name' => 'content', 'arguments' => array( 'action' => 'get' ) ),
-			'create_bricks_page'     => array( 'name' => 'content', 'arguments' => array( 'action' => 'create' ) ),
-			'update_bricks_content'  => array( 'name' => 'content', 'arguments' => array( 'action' => 'update_content' ) ),
-			'update_page'            => array( 'name' => 'content', 'arguments' => array( 'action' => 'update_meta' ) ),
-			'delete_page'            => array( 'name' => 'content', 'arguments' => array( 'action' => 'delete' ) ),
-			'duplicate_page'         => array( 'name' => 'content', 'arguments' => array( 'action' => 'duplicate' ) ),
-			'get_page_settings'      => array( 'name' => 'content', 'arguments' => array( 'action' => 'get_settings' ) ),
-			'update_page_settings'   => array( 'name' => 'content', 'arguments' => array( 'action' => 'update_settings' ) ),
-			'add_element'            => array( 'name' => 'content', 'arguments' => array( 'action' => 'add' ) ),
-			'update_element'         => array( 'name' => 'content', 'arguments' => array( 'action' => 'update' ) ),
-			'remove_element'         => array( 'name' => 'content', 'arguments' => array( 'action' => 'remove' ) ),
-			'get_condition_types'    => array( 'name' => 'template', 'arguments' => array( 'action' => 'get_types' ) ),
-			'set_template_conditions' => array( 'name' => 'template', 'arguments' => array( 'action' => 'set' ) ),
-			'resolve_templates'      => array( 'name' => 'template', 'arguments' => array( 'action' => 'resolve' ) ),
-			'list_template_tags'     => array( 'name' => 'template', 'arguments' => array( 'action' => 'list_tags' ) ),
-			'list_template_bundles'  => array( 'name' => 'template', 'arguments' => array( 'action' => 'list_bundles' ) ),
-			'create_template_tag'    => array( 'name' => 'template', 'arguments' => array( 'action' => 'create_tag' ) ),
-			'create_template_bundle' => array( 'name' => 'template', 'arguments' => array( 'action' => 'create_bundle' ) ),
-			'delete_template_tag'    => array( 'name' => 'template', 'arguments' => array( 'action' => 'delete_tag' ) ),
-			'delete_template_bundle' => array( 'name' => 'template', 'arguments' => array( 'action' => 'delete_bundle' ) ),
-			'enable_bricks'         => array( 'name' => 'bricks', 'arguments' => array( 'action' => 'enable' ) ),
-			'disable_bricks'        => array( 'name' => 'bricks', 'arguments' => array( 'action' => 'disable' ) ),
-			'get_bricks_settings'   => array( 'name' => 'bricks', 'arguments' => array( 'action' => 'get_settings' ) ),
-			'get_breakpoints'       => array( 'name' => 'bricks', 'arguments' => array( 'action' => 'get_breakpoints' ) ),
-			'get_element_schemas'   => array( 'name' => 'bricks', 'arguments' => array( 'action' => 'get_element_schemas' ) ),
-			'list_templates'        => array( 'name' => 'template', 'arguments' => array( 'action' => 'list' ) ),
-			'get_template_content'  => array( 'name' => 'template', 'arguments' => array( 'action' => 'get' ) ),
-			'create_template'       => array( 'name' => 'template', 'arguments' => array( 'action' => 'create' ) ),
-			'update_template'       => array( 'name' => 'template', 'arguments' => array( 'action' => 'update' ) ),
-			'delete_template'       => array( 'name' => 'template', 'arguments' => array( 'action' => 'delete' ) ),
-			'duplicate_template'    => array( 'name' => 'template', 'arguments' => array( 'action' => 'duplicate' ) ),
-			'get_global_classes'    => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_class', 'action' => 'list' ) ),
-			'create_global_class'   => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_class', 'action' => 'create' ) ),
-			'update_global_class'   => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_class', 'action' => 'update' ) ),
-			'delete_global_class'   => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_class', 'action' => 'delete' ) ),
-			'apply_global_class'    => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_class', 'action' => 'apply' ) ),
-			'remove_global_class'   => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_class', 'action' => 'remove' ) ),
-			'batch_create_global_classes' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_class', 'action' => 'batch_create' ) ),
-			'batch_delete_global_classes' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_class', 'action' => 'batch_delete' ) ),
-			'import_classes_from_css' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_class', 'action' => 'import_css' ) ),
-			'list_global_class_categories' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_class', 'action' => 'list_categories' ) ),
-			'create_global_class_category' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_class', 'action' => 'create_category' ) ),
-			'delete_global_class_category' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_class', 'action' => 'delete_category' ) ),
-			'list_theme_styles'     => array( 'name' => 'design', 'arguments' => array( 'domain' => 'theme_style', 'action' => 'list' ) ),
-			'get_theme_style'       => array( 'name' => 'design', 'arguments' => array( 'domain' => 'theme_style', 'action' => 'get' ) ),
-			'create_theme_style'    => array( 'name' => 'design', 'arguments' => array( 'domain' => 'theme_style', 'action' => 'create' ) ),
-			'update_theme_style'    => array( 'name' => 'design', 'arguments' => array( 'domain' => 'theme_style', 'action' => 'update' ) ),
-			'delete_theme_style'    => array( 'name' => 'design', 'arguments' => array( 'domain' => 'theme_style', 'action' => 'delete' ) ),
-			'get_typography_scales' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'typography_scale', 'action' => 'list' ) ),
-			'create_typography_scale' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'typography_scale', 'action' => 'create' ) ),
-			'update_typography_scale' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'typography_scale', 'action' => 'update' ) ),
-			'delete_typography_scale' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'typography_scale', 'action' => 'delete' ) ),
-			'list_color_palettes'  => array( 'name' => 'design', 'arguments' => array( 'domain' => 'color_palette', 'action' => 'list' ) ),
-			'create_color_palette' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'color_palette', 'action' => 'create' ) ),
-			'update_color_palette' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'color_palette', 'action' => 'update' ) ),
-			'delete_color_palette' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'color_palette', 'action' => 'delete' ) ),
-			'add_color_to_palette' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'color_palette', 'action' => 'add_color' ) ),
-			'update_color_in_palette' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'color_palette', 'action' => 'update_color' ) ),
-			'delete_color_from_palette' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'color_palette', 'action' => 'delete_color' ) ),
-			'list_global_variables' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_variable', 'action' => 'list' ) ),
-			'create_variable_category' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_variable', 'action' => 'create_category' ) ),
-			'update_variable_category' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_variable', 'action' => 'update_category' ) ),
-			'delete_variable_category' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_variable', 'action' => 'delete_category' ) ),
-			'create_global_variable' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_variable', 'action' => 'create' ) ),
-			'update_global_variable' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_variable', 'action' => 'update' ) ),
-			'delete_global_variable' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_variable', 'action' => 'delete' ) ),
-			'batch_create_global_variables' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_variable', 'action' => 'batch_create' ) ),
-			'batch_delete_global_variables' => array( 'name' => 'design', 'arguments' => array( 'domain' => 'global_variable', 'action' => 'batch_delete' ) ),
-			'get_media_library'     => array( 'name' => 'media', 'arguments' => array( 'action' => 'list' ) ),
-			'search_unsplash'       => array( 'name' => 'media', 'arguments' => array( 'action' => 'search_unsplash' ) ),
-			'sideload_image'        => array( 'name' => 'media', 'arguments' => array( 'action' => 'sideload' ) ),
-			'set_featured_image'    => array( 'name' => 'media', 'arguments' => array( 'action' => 'set_featured' ) ),
-			'remove_featured_image' => array( 'name' => 'media', 'arguments' => array( 'action' => 'remove_featured' ) ),
-			'get_image_element_settings' => array( 'name' => 'media', 'arguments' => array( 'action' => 'get_image_settings' ) ),
-			'list_menus'            => array( 'name' => 'menu', 'arguments' => array( 'action' => 'list' ) ),
-			'get_menu'              => array( 'name' => 'menu', 'arguments' => array( 'action' => 'get' ) ),
-			'create_menu'           => array( 'name' => 'menu', 'arguments' => array( 'action' => 'create' ) ),
-			'update_menu'           => array( 'name' => 'menu', 'arguments' => array( 'action' => 'update' ) ),
-			'delete_menu'           => array( 'name' => 'menu', 'arguments' => array( 'action' => 'delete' ) ),
 		);
 	}
 
@@ -796,35 +230,17 @@ final class Router {
 	/**
 	 * Get available tools in MCP format.
 	 *
-	 * @return array<int, array<string, mixed>> Tools list.
+	 * @return array<int, array{name: string, description: string, inputSchema: array}> Tools list.
 	 */
 	public function get_available_tools(): array {
 		$tools = array();
 
 		foreach ( $this->tools as $tool ) {
-			if ( ! in_array( $tool['name'], self::VISIBLE_TOOL_NAMES, true ) ) {
-				continue;
-			}
-
-			$available_tool = array(
+			$tools[] = array(
 				'name'        => $tool['name'],
 				'description' => $tool['description'],
 				'inputSchema' => $tool['inputSchema'],
 			);
-
-			if ( isset( $tool['annotations'] ) ) {
-				$available_tool['annotations'] = $tool['annotations'];
-			}
-
-			if ( isset( $tool['outputSchema'] ) ) {
-				$available_tool['outputSchema'] = $tool['outputSchema'];
-			}
-
-			if ( isset( $tool['defaults'] ) ) {
-				$available_tool['defaults'] = $tool['defaults'];
-			}
-
-			$tools[] = $available_tool;
 		}
 
 		return $tools;
@@ -838,21 +254,6 @@ final class Router {
 	 * @return \WP_REST_Response The response.
 	 */
 	public function execute_tool( string $name, array $arguments ): \WP_REST_Response {
-		$resolved = $this->resolve_tool_call( $name, $arguments );
-
-		if ( is_wp_error( $resolved ) ) {
-			return Response::error(
-				'unknown_tool',
-				$resolved->get_error_message(),
-				404,
-				null,
-				__( 'Call tools/list to discover the supported canonical tool names and aliases.', 'bricks-mcp' )
-			);
-		}
-
-		$name      = $resolved['name'];
-		$arguments = $resolved['arguments'];
-
 		if ( ! isset( $this->tools[ $name ] ) ) {
 			return Response::error(
 				'unknown_tool',
@@ -891,15 +292,12 @@ final class Router {
 				return Response::tool_error( $result );
 			}
 
-			$result          = $this->format_tool_result( $name, $result, $arguments['response_format'] ?? 'verbose' );
-			$encoded_result  = is_string( $result ) ? $result : wp_json_encode( $result, JSON_PRETTY_PRINT );
-
 			return Response::success(
 				array(
 					'content' => array(
 						array(
 							'type' => 'text',
-							'text' => $encoded_result,
+							'text' => is_string( $result ) ? $result : wp_json_encode( $result, JSON_PRETTY_PRINT ),
 						),
 					),
 				)
@@ -925,7 +323,6 @@ final class Router {
 		$public_tools = array(
 			'get_builder_guide',
 			'wordpress', // Per-action checks handled inside tool_wordpress().
-			'content',   // Per-action checks handled inside content dispatcher.
 		);
 
 		if ( in_array( $tool_name, $public_tools, true ) ) {
@@ -1273,8 +670,8 @@ final class Router {
 					),
 					'view'                => array(
 						'type'        => 'string',
-						'enum'        => array( 'detail', 'summary' ),
-						'description' => __( 'Detail level (get: detail=full settings, summary=tree outline)', 'bricks-mcp' ),
+						'enum'        => array( 'detail', 'summary', 'visual' ),
+						'description' => __( 'Detail level (get: detail=full settings, summary=type counts + tree, visual=human-readable layout tree with element IDs, global classes, and content hints - use before editing existing pages)', 'bricks-mcp' ),
 					),
 					'title'               => array(
 						'type'        => 'string',
@@ -1341,6 +738,23 @@ final class Router {
 			),
 			array( $this, 'tool_page' )
 		);
+
+		// page_diagnose: scan existing pages for known issues before editing.
+$this->register_tool(
+    'page_diagnose',
+    __( 'Scan a Bricks page or template for issues before editing. Returns structured report with element ID, severity, type, message, and fix for each issue found. Checks: scripts missing <script> tags, %root% in _cssCustom, _maxWidth key, plain-string colors, invalid breakpoint keys, orphaned children, phantom _bricks_page_content_2 on header/footer templates, missing global classes, integer border values, and code elements with PHP that lack executeCode. Call this before editing any existing page. Read-only - makes no changes.', 'bricks-mcp' ),
+    array(
+        'type'       => 'object',
+        'properties' => array(
+            'post_id' => array(
+                'type'        => 'integer',
+                'description' => __( 'Post/page/template ID to diagnose (required)', 'bricks-mcp' ),
+            ),
+        ),
+        'required' => array( 'post_id' ),
+    ),
+    array( $this, 'tool_page_diagnose' )
+);
 
 		// Element consolidated tool (replaces add_element, update_element, remove_element).
 		$this->register_tool(
@@ -1416,13 +830,13 @@ final class Router {
 		// Template consolidated tool (replaces list_templates, get_template_content, create_template, update_template, delete_template, duplicate_template).
 		$this->register_tool(
 			'template',
-			__( 'Manage Bricks templates and targeting rules for a given site; requires an action and validates template-specific inputs.', 'bricks-mcp' ),
+			__( "Manage Bricks templates (headers, footers, sections, popups, etc.).\n\nActions:\n- list: List templates (optional: type, status, tag, bundle)\n- get: Get template with element content (requires: template_id)\n- create: Create template (requires: title, type; optional: elements, status, tags, bundles)\n- update: Update template metadata (requires: template_id; optional: title, status, type, tags, bundles)\n- delete: Delete template (requires: template_id)\n- duplicate: Duplicate template (requires: template_id; optional: title)\n- get_popup_settings: Get popup display settings (requires: template_id; template must be type popup)\n- set_popup_settings: Set popup display settings (requires: template_id, settings; template must be type popup)\n- export: Export template as Bricks-compatible JSON (requires: template_id; optional: include_classes)\n- import: Import template from JSON data (requires: template_data)\n- import_url: Import template from remote URL (requires: url)", 'bricks-mcp' ),
 			array(
 				'type'       => 'object',
 				'properties' => array(
 					'action'      => array(
 						'type'        => 'string',
-						'enum'        => array( 'list', 'get', 'create', 'update', 'delete', 'duplicate', 'get_popup_settings', 'set_popup_settings', 'export', 'import', 'import_url', 'get_types', 'set', 'resolve', 'list_tags', 'list_bundles', 'create_tag', 'create_bundle', 'delete_tag', 'delete_bundle' ),
+						'enum'        => array( 'list', 'get', 'create', 'update', 'delete', 'duplicate', 'get_popup_settings', 'set_popup_settings', 'export', 'import', 'import_url' ),
 						'description' => __( 'Action to perform', 'bricks-mcp' ),
 					),
 					'template_id' => array(
@@ -1472,14 +886,6 @@ final class Router {
 					'conditions'  => array(
 						'type'        => 'array',
 						'description' => __( 'Array of Bricks condition objects (create: optional)', 'bricks-mcp' ),
-					),
-					'post_id'     => array(
-						'type'        => 'integer',
-						'description' => __( 'Post ID for resolve action.', 'bricks-mcp' ),
-					),
-					'term_id'     => array(
-						'type'        => 'integer',
-						'description' => __( 'Template taxonomy term ID for delete_tag/delete_bundle.', 'bricks-mcp' ),
 					),
 					'settings'    => array(
 						'type'        => 'object',
@@ -1561,13 +967,6 @@ final class Router {
 				'required'   => array( 'action' ),
 			),
 			array( $this, 'tool_template_taxonomy' )
-		);
-
-		$this->register_tool(
-			'design',
-			__( 'Manage Bricks design tokens and style systems for a given site; requires a design domain and an action.', 'bricks-mcp' ),
-			$this->get_design_tool_schema(),
-			array( $this, 'tool_design' )
 		);
 
 		// Global class consolidated tool (replaces get_global_classes, create_global_class, update_global_class, delete_global_class, apply_global_class, remove_global_class, batch_create_global_classes, batch_delete_global_classes, import_classes_from_css, list_global_class_categories, create_global_class_category, delete_global_class_category).
@@ -2171,51 +1570,6 @@ final class Router {
 				)
 			),
 		};
-	}
-
-	/**
-	 * Tool: Content dispatcher — routes to WordPress, page, and element operations.
-	 *
-	 * @param array<string, mixed> $args Tool arguments including action.
-	 * @return array<string, mixed>|\WP_Error
-	 */
-	public function tool_content( array $args ): array|\WP_Error {
-		$action = $args['action'] ?? '';
-
-		$read_actions = array( 'get_posts', 'get_post', 'get_users', 'get_plugins' );
-		$required_cap = in_array( $action, $read_actions, true ) ? null : 'manage_options';
-
-		if ( null !== $required_cap && ! current_user_can( $required_cap ) ) {
-			return new \WP_Error(
-				'bricks_mcp_forbidden',
-				sprintf(
-					/* translators: %s: Capability name */
-					__( 'You do not have the required capability (%s) to use this action.', 'bricks-mcp' ),
-					$required_cap
-				)
-			);
-		}
-
-		if ( in_array( $action, array( 'get_posts', 'get_post', 'get_users', 'get_plugins' ), true ) ) {
-			return $this->tool_wordpress( $args );
-		}
-
-		if ( in_array( $action, array( 'list', 'search', 'get', 'create', 'update_content', 'update_meta', 'delete', 'duplicate', 'get_settings', 'update_settings', 'get_seo', 'update_seo' ), true ) ) {
-			return $this->tool_page( $args );
-		}
-
-		if ( in_array( $action, array( 'add', 'update', 'remove', 'get_conditions', 'set_conditions', 'move', 'bulk_update' ), true ) ) {
-			return $this->tool_element( $args );
-		}
-
-		return new \WP_Error(
-			'invalid_action',
-			sprintf(
-				/* translators: %s: Action name */
-				__( 'Invalid action "%s" for content tool.', 'bricks-mcp' ),
-				$action
-			)
-		);
 	}
 
 	/**
@@ -3894,6 +3248,13 @@ final class Router {
 			);
 		}
 
+		if ( 'visual' === $view ) {
+			return array(
+				'metadata' => $metadata,
+				'visual'   => $this->bricks_service->get_visual_layout( $post_id ),
+			);
+		}
+
 		return array(
 			'metadata' => $metadata,
 			'elements' => $this->bricks_service->get_elements( $post_id ),
@@ -4606,20 +3967,11 @@ final class Router {
 			'export'              => $this->tool_export_template( $args ),
 			'import'              => $this->tool_import_template( $args ),
 			'import_url'          => $this->tool_import_template_url( $args ),
-			'get_types'           => $this->tool_get_condition_types( $args ),
-			'set'                 => $this->tool_set_template_conditions( $args ),
-			'resolve'             => $this->tool_resolve_templates( $args ),
-			'list_tags'           => $this->tool_list_template_tags( $args ),
-			'list_bundles'        => $this->tool_list_template_bundles( $args ),
-			'create_tag'          => $this->tool_create_template_tag( $args ),
-			'create_bundle'       => $this->tool_create_template_bundle( $args ),
-			'delete_tag'          => $this->tool_delete_template_tag( $args ),
-			'delete_bundle'       => $this->tool_delete_template_bundle( $args ),
 			default               => new \WP_Error(
 				'invalid_action',
 				sprintf(
 					/* translators: %s: Action name */
-					__( 'Invalid action "%s". Valid actions: list, get, create, update, delete, duplicate, get_popup_settings, set_popup_settings, export, import, import_url, get_types, set, resolve, list_tags, list_bundles, create_tag, create_bundle, delete_tag, delete_bundle', 'bricks-mcp' ),
+					__( 'Invalid action "%s". Valid actions: list, get, create, update, delete, duplicate, get_popup_settings, set_popup_settings, export, import, import_url', 'bricks-mcp' ),
 					$action
 				)
 			),
@@ -4789,33 +4141,6 @@ final class Router {
 					/* translators: %s: Action name */
 					__( 'Invalid action "%s". Valid actions: list_tags, list_bundles, create_tag, create_bundle, delete_tag, delete_bundle', 'bricks-mcp' ),
 					$action
-				)
-			),
-		};
-	}
-
-	/**
-	 * Tool: Design dispatcher — routes to the appropriate Bricks design subsystem.
-	 *
-	 * @param array<string, mixed> $args Tool arguments including action and domain.
-	 * @return array<string, mixed>|\WP_Error Result data or error.
-	 */
-	public function tool_design( array $args ): array|\WP_Error {
-		$domain = $args['domain'] ?? '';
-
-		return match ( $domain ) {
-			'global_class'     => $this->tool_global_class( $args ),
-			'theme_style'      => $this->tool_theme_style( $args ),
-			'typography_scale' => $this->tool_typography_scale( $args ),
-			'color_palette'    => $this->tool_color_palette( $args ),
-			'global_variable'  => $this->tool_global_variable( $args ),
-			'font'             => $this->tool_font( $args ),
-			default            => new \WP_Error(
-				'invalid_domain',
-				sprintf(
-					/* translators: %s: Domain name */
-					__( 'Invalid design domain "%s". Valid domains: global_class, theme_style, typography_scale, color_palette, global_variable, font', 'bricks-mcp' ),
-					(string) $domain
 				)
 			),
 		};
@@ -10034,6 +9359,210 @@ final class Router {
 			'total_skipped' => count( $skipped ),
 			'total_failed'  => count( $failed ),
 			'next_steps'    => 'Use template:get to view and customize individual templates. Use page:update_content or element:add/update to modify elements. Use get_builder_guide(section="woocommerce") for patterns.',
+		);
+	}
+	
+	/**
+	 * Tool: Diagnose a Bricks page for known issues before editing.
+	 *
+	 * @param array<string, mixed> $args Tool arguments.
+	 * @return array<string, mixed>|\WP_Error Diagnosis report or error.
+	 */
+	public function tool_page_diagnose( array $args ): array|\WP_Error {
+		$bricks_error = $this->require_bricks();
+		if ( null !== $bricks_error ) {
+			return $bricks_error;
+		}
+
+		if ( empty( $args['post_id'] ) ) {
+			return new \WP_Error( 'missing_post_id', __( 'post_id is required.', 'bricks-mcp' ) );
+		}
+
+		$post_id = (int) $args['post_id'];
+		$post    = get_post( $post_id );
+
+		if ( ! $post ) {
+			return new \WP_Error( 'post_not_found', sprintf( __( 'Post %d not found.', 'bricks-mcp' ), $post_id ) );
+		}
+
+		$elements = $this->bricks_service->get_elements( $post_id );
+		$issues   = array();
+
+		$id_map = array();
+		foreach ( $elements as $el ) {
+			$id_map[ $el['id'] ] = true;
+		}
+
+		$global_classes   = $this->bricks_service->get_global_classes();
+		$global_class_ids = array();
+		foreach ( $global_classes as $gc ) {
+			$global_class_ids[ $gc['id'] ?? '' ] = true;
+		}
+
+		$template_type    = get_post_meta( $post_id, '_bricks_template_type', true );
+		$is_header_footer = in_array( $template_type, array( 'header', 'footer' ), true );
+
+		if ( $is_header_footer ) {
+			$phantom = get_post_meta( $post_id, '_bricks_page_content_2', true );
+			if ( ! empty( $phantom ) ) {
+				$issues[] = array(
+					'element_id' => null,
+					'severity'   => 'error',
+					'type'       => 'phantom_content',
+					'message'    => ucfirst( $template_type ) . ' template has phantom _bricks_page_content_2 that renders a ghost section below the real template.',
+					'fix'        => 'Run: delete_post_meta( ' . $post_id . ", '_bricks_page_content_2' )",
+				);
+			}
+		}
+
+		$valid_bps = array( 'tablet_landscape', 'tablet_portrait', 'mobile_landscape', 'mobile_portrait' );
+
+		foreach ( $elements as $el ) {
+			$el_id    = $el['id'] ?? 'unknown';
+			$el_name  = $el['name'] ?? 'unknown';
+			$settings = $el['settings'] ?? array();
+
+			foreach ( array( 'customScriptsBodyFooter', 'customScriptsBodyHeader', 'customScriptsHeader' ) as $sf ) {
+				if ( ! empty( $settings[ $sf ] ) && strpos( $settings[ $sf ], '<script' ) === false ) {
+					$issues[] = array(
+						'element_id' => $el_id,
+						'severity'   => 'error',
+						'type'       => 'script_missing_tags',
+						'message'    => "Element {$el_id} ({$el_name}): {$sf} has JS without <script> tags - will print as visible text.",
+						'fix'        => 'Wrap the content in <script>...</script> tags.',
+					);
+				}
+			}
+
+			if ( 'code' === $el_name && ! empty( $settings['code'] ) && strpos( $settings['code'], '<?php' ) !== false && empty( $settings['executeCode'] ) ) {
+				$issues[] = array(
+					'element_id' => $el_id,
+					'severity'   => 'warning',
+					'type'       => 'php_execute_disabled',
+					'message'    => "Element {$el_id}: code element contains PHP but executeCode is not enabled.",
+					'fix'        => 'Set settings.executeCode = true on this element.',
+				);
+			}
+
+			if ( ! empty( $settings['_cssCustom'] ) && strpos( $settings['_cssCustom'], '%root%' ) !== false ) {
+				$issues[] = array(
+					'element_id' => $el_id,
+					'severity'   => 'error',
+					'type'       => 'root_placeholder',
+					'message'    => "Element {$el_id} ({$el_name}): _cssCustom uses %root% which only works in the visual editor, not via API.",
+					'fix'        => "Replace %root% with #brxe-{$el_id}",
+				);
+			}
+
+			if ( array_key_exists( '_maxWidth', $settings ) ) {
+				$issues[] = array(
+					'element_id' => $el_id,
+					'severity'   => 'error',
+					'type'       => 'wrong_key_maxwidth',
+					'message'    => "Element {$el_id} ({$el_name}): uses _maxWidth which is silently ignored.",
+					'fix'        => 'Rename _maxWidth to _widthMax.',
+				);
+			}
+
+			foreach ( array( '_background', 'color', 'iconColor' ) as $ck ) {
+				if ( isset( $settings[ $ck ] ) && is_string( $settings[ $ck ] ) && preg_match( '/^#[0-9a-fA-F]{3,8}$/', $settings[ $ck ] ) ) {
+					$issues[] = array(
+						'element_id' => $el_id,
+						'severity'   => 'warning',
+						'type'       => 'plain_string_color',
+						'message'    => "Element {$el_id} ({$el_name}): {$ck} is a plain hex string. Bricks expects {\"hex\":\"#value\"} objects.",
+						'fix'        => "Change {$ck} to {\"hex\":\"{$settings[$ck]}\"}.",
+					);
+				}
+			}
+
+			foreach ( array_keys( $settings ) as $key ) {
+    if ( strpos( $key, ':' ) !== false ) {
+        $bp = explode( ':', $key, 2 )[1] ?? '';
+        // Skip pseudo states — they are not breakpoints.
+        $valid_pseudo = array( 'hover', 'focus', 'active', 'visited', 'placeholder', 'before', 'after' );
+        if ( in_array( $bp, $valid_pseudo, true ) ) {
+            continue;
+        }
+        if ( ! empty( $bp ) && ! in_array( $bp, $valid_bps, true ) ) {
+            $issues[] = array(
+                'element_id' => $el_id,
+                'severity'   => 'warning',
+                'type'       => 'invalid_breakpoint',
+                'message'    => "Element {$el_id}: setting key '{$key}' uses unknown breakpoint '{$bp}'.",
+                'fix'        => 'Valid breakpoints: tablet_landscape, tablet_portrait, mobile_landscape, mobile_portrait.',
+            );
+        }
+    }
+}
+			foreach ( ( $el['children'] ?? array() ) as $child_id ) {
+				if ( ! isset( $id_map[ $child_id ] ) ) {
+					$issues[] = array(
+						'element_id' => $el_id,
+						'severity'   => 'error',
+						'type'       => 'orphaned_child',
+						'message'    => "Element {$el_id}: child ID '{$child_id}' does not exist in the page.",
+						'fix'        => "Remove '{$child_id}' from element {$el_id} children array.",
+					);
+				}
+			}
+
+			if ( ! empty( $settings['_cssClasses'] ) ) {
+				$used = is_array( $settings['_cssClasses'] ) ? $settings['_cssClasses'] : explode( ' ', $settings['_cssClasses'] );
+				foreach ( $used as $cid ) {
+					$cid = trim( $cid );
+					if ( ! empty( $cid ) && ! isset( $global_class_ids[ $cid ] ) ) {
+						$issues[] = array(
+							'element_id' => $el_id,
+							'severity'   => 'warning',
+							'type'       => 'missing_global_class',
+							'message'    => "Element {$el_id}: references global class '{$cid}' which does not exist.",
+							'fix'        => 'Create the class via global_class:create or remove the reference.',
+						);
+					}
+				}
+			}
+
+			if ( ! empty( $settings['_border'] ) && is_array( $settings['_border'] ) ) {
+				if ( isset( $settings['_border']['width'] ) && is_int( $settings['_border']['width'] ) ) {
+					$w        = $settings['_border']['width'];
+					$issues[] = array(
+						'element_id' => $el_id,
+						'severity'   => 'warning',
+						'type'       => 'integer_border',
+						'message'    => "Element {$el_id}: _border.width is integer {$w}, Bricks expects a CSS string like '{$w}px'.",
+						'fix'        => "Change _border.width from {$w} to '{$w}px'.",
+					);
+				}
+				if ( ! empty( $settings['_border']['radius'] ) && is_array( $settings['_border']['radius'] ) ) {
+					foreach ( $settings['_border']['radius'] as $side => $val ) {
+						if ( is_int( $val ) ) {
+							$issues[] = array(
+								'element_id' => $el_id,
+								'severity'   => 'warning',
+								'type'       => 'integer_border_radius',
+								'message'    => "Element {$el_id}: _border.radius.{$side} is integer {$val}, expects CSS string like '{$val}px'.",
+								'fix'        => "Change _border.radius.{$side} from {$val} to '{$val}px'.",
+							);
+							break;
+						}
+					}
+				}
+			}
+		}
+
+		$errors   = count( array_filter( $issues, fn( $i ) => 'error' === $i['severity'] ) );
+		$warnings = count( array_filter( $issues, fn( $i ) => 'warning' === $i['severity'] ) );
+
+		return array(
+			'post_id'       => $post_id,
+			'title'         => $post->post_title,
+			'element_count' => count( $elements ),
+			'issue_count'   => count( $issues ),
+			'error_count'   => $errors,
+			'warning_count' => $warnings,
+			'status'        => 0 === count( $issues ) ? 'clean' : ( $errors > 0 ? 'errors' : 'warnings' ),
+			'issues'        => $issues,
 		);
 	}
 }

--- a/includes/MCP/Services/BricksService.php
+++ b/includes/MCP/Services/BricksService.php
@@ -2439,7 +2439,7 @@ class BricksService {
 		$label = $settings['_label'] ?? $name;
 
 		// Global classes applied to this element.
-		$css_classes = $settings['_cssClasses'] ?? [];
+		$css_classes = $settings['_cssGlobalClasses'] ?? [];
 		if ( is_string( $css_classes ) ) {
 			$css_classes = array_filter( array_map( 'trim', explode( ' ', $css_classes ) ) );
 		}
@@ -7810,4 +7810,103 @@ class BricksService {
 			'warning'  => __( 'Scripts are executed on page load. Test carefully.', 'bricks-mcp' ),
 		);
 	}
+	
+	/**
+	 * Diagnose a Bricks page for known issues before editing.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array<string, mixed> Diagnostic report.
+	 */
+	public function diagnose_page( int $post_id ): array {
+		$post     = get_post( $post_id );
+		$elements = $this->get_elements( $post_id );
+		$issues   = array();
+		$id_map   = array();
+		foreach ( $elements as $el ) { $id_map[ $el['id'] ] = true; }
+		$gcs    = $this->get_global_classes();
+		$gc_ids = array();
+		foreach ( $gcs as $gc ) { $gc_ids[ $gc['id'] ?? '' ] = true; }
+		$ttype = get_post_meta( $post_id, '_bricks_template_type', true );
+		if ( in_array( $ttype, array( 'header', 'footer' ), true ) ) {
+			if ( ! empty( get_post_meta( $post_id, '_bricks_page_content_2', true ) ) ) {
+				$issues[] = array( 'element_id' => null, 'severity' => 'error', 'type' => 'phantom_content', 'message' => ucfirst( $ttype ) . ' has phantom _bricks_page_content_2.', 'fix' => 'Run delete_post_meta( ' . $post_id . ", '_bricks_page_content_2' )" );
+			}
+		}
+		$bps = array_column( $this->get_breakpoints(), 'key' );
+		if ( empty( $bps ) ) { $bps = array( 'tablet_landscape', 'tablet_portrait', 'mobile_landscape', 'mobile_portrait', 'mobile' ); }
+		foreach ( $elements as $el ) {
+			$el_id    = $el['id'] ?? 'unknown';
+			$el_name  = $el['name'] ?? 'unknown';
+			$settings = $el['settings'] ?? array();
+			foreach ( array( 'customScriptsBodyFooter', 'customScriptsBodyHeader', 'customScriptsHeader' ) as $sf ) {
+				if ( ! empty( $settings[ $sf ] ) && strpos( $settings[ $sf ], '<script' ) === false ) {
+					$issues[] = array( 'element_id' => $el_id, 'severity' => 'error', 'type' => 'script_missing_tags', 'message' => "Element {$el_id} ({$el_name}): {$sf} has JS without <script> tags.", 'fix' => 'Wrap in <script>...</script>.' );
+				}
+			}
+			if ( 'code' === $el_name && ! empty( $settings['code'] ) && strpos( $settings['code'], '<?php' ) !== false && empty( $settings['executeCode'] ) ) {
+				$issues[] = array( 'element_id' => $el_id, 'severity' => 'warning', 'type' => 'php_execute_disabled', 'message' => "Element {$el_id}: code element has PHP but executeCode is not enabled.", 'fix' => 'Set settings.executeCode = true.' );
+			}
+			if ( ! empty( $settings['_cssCustom'] ) && strpos( $settings['_cssCustom'], '%root%' ) !== false ) {
+				$issues[] = array( 'element_id' => $el_id, 'severity' => 'error', 'type' => 'root_placeholder', 'message' => "Element {$el_id}: _cssCustom uses %root%.", 'fix' => "Replace %root% with #brxe-{$el_id}" );
+			}
+			if ( array_key_exists( '_maxWidth', $settings ) ) {
+				$issues[] = array( 'element_id' => $el_id, 'severity' => 'error', 'type' => 'wrong_key_maxwidth', 'message' => "Element {$el_id}: uses _maxWidth.", 'fix' => 'Rename to _widthMax.' );
+			}
+			foreach ( array( '_background', 'color', 'iconColor' ) as $ck ) {
+				if ( isset( $settings[ $ck ] ) && is_string( $settings[ $ck ] ) && preg_match( '/^#[0-9a-fA-F]{3,8}$/', $settings[ $ck ] ) ) {
+					$issues[] = array( 'element_id' => $el_id, 'severity' => 'warning', 'type' => 'plain_string_color', 'message' => "Element {$el_id}: {$ck} is a plain hex string.", 'fix' => 'Change ' . $ck . ' to {"hex":"' . $settings[ $ck ] . '"}.' );
+				}
+			}
+			foreach ( array_keys( $settings ) as $key ) {
+				if ( strpos( $key, ':' ) === false ) { continue; }
+				$pseudo  = array( 'hover', 'focus', 'active', 'visited', 'placeholder', 'before', 'after' );
+				$segs    = explode( ':', $key );
+				array_shift( $segs );
+				$bad     = false;
+				$bad_seg = '';
+				foreach ( $segs as $seg ) {
+					if ( in_array( $seg, $pseudo, true ) ) { continue; }
+					if ( strpos( $seg, 'variant-' ) === 0 ) { continue; }
+					if ( ! in_array( $seg, $bps, true ) ) { $bad = true; $bad_seg = $seg; break; }
+				}
+				if ( $bad ) {
+					$issues[] = array( 'element_id' => $el_id, 'severity' => 'warning', 'type' => 'invalid_breakpoint', 'message' => "Element {$el_id}: key '{$key}' has unknown segment '{$bad_seg}'.", 'fix' => 'Valid IDs: ' . implode( ', ', $bps ) . '. Pseudo-states and variant-* are valid.' );
+				}
+			}
+			foreach ( ( $el['children'] ?? array() ) as $child_id ) {
+				if ( ! isset( $id_map[ $child_id ] ) ) {
+					$issues[] = array( 'element_id' => $el_id, 'severity' => 'error', 'type' => 'orphaned_child', 'message' => "Element {$el_id}: child '{$child_id}' does not exist.", 'fix' => "Remove '{$child_id}' from children." );
+				}
+			}
+			if ( ! empty( $settings['_cssGlobalClasses'] ) ) {
+				$used = is_array( $settings['_cssGlobalClasses'] ) ? $settings['_cssGlobalClasses'] : explode( ' ', $settings['_cssGlobalClasses'] );
+				foreach ( $used as $cid ) {
+					$cid = trim( $cid );
+					if ( ! empty( $cid ) && ! isset( $gc_ids[ $cid ] ) ) {
+						$issues[] = array( 'element_id' => $el_id, 'severity' => 'warning', 'type' => 'missing_global_class', 'message' => "Element {$el_id}: references missing class '{$cid}'.", 'fix' => 'Create via global_class:create or remove.' );
+					}
+				}
+			}
+			if ( ! empty( $settings['_border'] ) && is_array( $settings['_border'] ) ) {
+				if ( isset( $settings['_border']['width'] ) && is_int( $settings['_border']['width'] ) ) {
+					$w = $settings['_border']['width'];
+					$issues[] = array( 'element_id' => $el_id, 'severity' => 'warning', 'type' => 'integer_border', 'message' => "Element {$el_id}: _border.width is integer {$w}.", 'fix' => "Change to '{$w}px'." );
+				}
+			}
+		}
+		$errors   = count( array_filter( $issues, fn( $i ) => 'error' === $i['severity'] ) );
+		$warnings = count( array_filter( $issues, fn( $i ) => 'warning' === $i['severity'] ) );
+		return array(
+			'post_id'       => $post_id,
+			'title'         => $post ? $post->post_title : '',
+			'element_count' => count( $elements ),
+			'issue_count'   => count( $issues ),
+			'error_count'   => $errors,
+			'warning_count' => $warnings,
+			'status'        => 0 === count( $issues ) ? 'clean' : ( $errors > 0 ? 'errors' : 'warnings' ),
+			'issues'        => $issues,
+		);
+	}
+	
 }
+

--- a/includes/MCP/Services/BricksService.php
+++ b/includes/MCP/Services/BricksService.php
@@ -2362,7 +2362,144 @@ class BricksService {
 		return $this->save_elements( $post_id, $elements );
 	}
 
+	
 	/**
+	 * Get a human-readable visual layout tree for a page.
+	 *
+	 * Returns a nested tree with element IDs, names, labels, depth,
+	 * global classes, text previews, and background color hints.
+	 * Use this with view=visual on page:get to understand existing page structure before editing.
+	 *
+	 * @param int $post_id The post ID.
+	 * @return array<string, mixed> Visual layout tree.
+	 */
+	public function get_visual_layout( int $post_id ): array {
+		$elements = $this->get_elements( $post_id );
+
+		if ( empty( $elements ) ) {
+			return [
+				'tree'  => [],
+				'total' => 0,
+			];
+		}
+
+		// Build ID → element map and children map.
+		$el_map      = [];
+		$children_of = [];
+
+		foreach ( $elements as $el ) {
+			$id = $el['id'] ?? '';
+			if ( ''  === $id ) {
+				continue;
+			}
+			$el_map[ $id ] = $el;
+		}
+
+		foreach ( $elements as $el ) {
+			$id     = $el['id'] ?? '';
+			$parent = $el['parent'] ?? 0;
+			if ( ''  === $id ) {
+				continue;
+			}
+			$parent_key = ( 0 === $parent || '0' === $parent ) ? '__root__' : (string) $parent;
+			$children_of[ $parent_key ][] = $id;
+		}
+
+		// Build tree from root elements.
+		$root_ids = $children_of['__root__'] ?? [];
+		$tree     = [];
+
+		foreach ( $root_ids as $root_id ) {
+			if ( isset( $el_map[ $root_id ] ) ) {
+				$tree[] = $this->build_visual_node( $el_map[ $root_id ], $el_map, $children_of, 0 );
+			}
+		}
+
+		return [
+			'tree'  => $tree,
+			'total' => count( $elements ),
+		];
+	}
+
+	/**
+	 * Build a single visual node for the layout tree.
+	 *
+	 * @param array<string, mixed>              $el          The element data.
+	 * @param array<string, array<string,mixed>> $el_map      Map of all elements by ID.
+	 * @param array<string, string[]>            $children_of Map of parent ID to child IDs.
+	 * @param int                               $depth       Current nesting depth.
+	 * @return array<string, mixed> Visual node.
+	 */
+	private function build_visual_node( array $el, array $el_map, array $children_of, int $depth ): array {
+		$id       = $el['id'] ?? '';
+		$name     = $el['name'] ?? 'unknown';
+		$settings = $el['settings'] ?? [];
+
+		// Label: prefer _label setting, fall back to element name.
+		$label = $settings['_label'] ?? $name;
+
+		// Global classes applied to this element.
+		$css_classes = $settings['_cssClasses'] ?? [];
+		if ( is_string( $css_classes ) ) {
+			$css_classes = array_filter( array_map( 'trim', explode( ' ', $css_classes ) ) );
+		}
+
+		// Text preview from common text-bearing settings (max 80 chars).
+		$text_preview = null;
+		foreach ( [ 'text', 'content', 'heading', 'label' ] as $tk ) {
+			if ( ! empty( $settings[ $tk ] ) && is_string( $settings[ $tk ] ) ) {
+				$raw          = wp_strip_all_tags( $settings[ $tk ] );
+				$text_preview = mb_strlen( $raw ) > 80 ? mb_substr( $raw, 0, 77 ) . '...' : $raw;
+				break;
+			}
+		}
+
+		// Background color hint.
+		$bg_color = null;
+		$bg       = $settings['_background'] ?? [];
+		if ( is_array( $bg ) ) {
+			$color = $bg['color'] ?? [];
+			if ( is_array( $color ) ) {
+				$bg_color = $color['hex'] ?? ( $color['raw'] ?? null );
+			} elseif ( is_string( $color ) ) {
+				$bg_color = $color;
+			}
+		}
+
+		$node = [
+			'id'    => $id,
+			'name'  => $name,
+			'label' => $label,
+			'depth' => $depth,
+		];
+
+		if ( ! empty( $css_classes ) ) {
+			$node['global_classes'] = array_values( $css_classes );
+		}
+
+		if ( null !== $text_preview ) {
+			$node['text_preview'] = $text_preview;
+		}
+
+		if ( null !== $bg_color ) {
+			$node['bg_color'] = $bg_color;
+		}
+
+		// Recurse into children.
+		$child_ids = $children_of[ $id ] ?? [];
+		if ( ! empty( $child_ids ) ) {
+			$node['children'] = [];
+			foreach ( $child_ids as $cid ) {
+				if ( isset( $el_map[ $cid ] ) ) {
+					$node['children'][] = $this->build_visual_node( $el_map[ $cid ], $el_map, $children_of, $depth + 1 );
+				}
+			}
+		}
+
+		return $node;
+	}
+
+/**
 	 * Get a tree outline summary of a page's Bricks elements.
 	 *
 	 * Returns element names/IDs in tree structure with type counts.


### PR DESCRIPTION
- Add page_diagnose tool: scans pages for 10 common Bricks issues before editing
- Add page:get view=visual: returns human-readable nested layout tree with element IDs, labels, text previews, and bg colors
- Fix pseudo-state false positive in breakpoint checker (hover, focus, etc.)