### PR TITLE
fix(tests): resolve 2 CI unit test failures on main

### DIFF
--- a/includes/MCP/Response.php
+++ b/includes/MCP/Response.php
@@ -96,7 +96,7 @@ final class Response {
 		];
 
 		$data = $error->get_error_data();
-		if ( null !== $data && '' !== $data ) {
+		if ( null !== $data ) {
 			if ( is_scalar( $data ) ) {
 				$payload['data'] = $data;
 			} elseif ( is_array( $data ) ) {

--- a/includes/MCP/Response.php
+++ b/includes/MCP/Response.php
@@ -96,7 +96,7 @@ final class Response {
 		];
 
 		$data = $error->get_error_data();
-		if ( null !== $data ) {
+		if ( null !== $data && '' !== $data ) {
 			if ( is_scalar( $data ) ) {
 				$payload['data'] = $data;
 			} elseif ( is_array( $data ) ) {

--- a/tests/Unit/BugFixesTest.php
+++ b/tests/Unit/BugFixesTest.php
@@ -136,7 +136,7 @@ final class BugFixesTest extends TestCase {
 	 * @return void
 	 */
 	public function test_create_global_class_has_readback(): void {
-		$body = $this->extract_method_body( 'create_global_class' );
+		$body = $this->extract_method_body( 'create_global_class', 3000 );
 		$this->assertStringContainsString(
 			'wp_cache_delete',
 			$body,

--- a/tests/stubs/wp-functions.php
+++ b/tests/stubs/wp-functions.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'WP_Error' ) ) {
 		 * @param string $message Error message.
 		 * @param mixed  $data    Additional data.
 		 */
-		public function __construct( string $code = '', string $message = '', mixed $data = '' ) {
+		public function __construct( string $code = '', string $message = '', mixed $data = null ) {
 			$this->code    = $code;
 			$this->message = $message;
 			$this->data    = $data;


### PR DESCRIPTION
## Summary

Fixes the **Unit Tests** CI job that fails on every push to `main` (2 PHPUnit failures, ~13s runtime).

## Root cause

1. **BugFixesTest::test_create_global_class_has_readback** — `extract_method_body('create_global_class')` used the 2000-char default window, truncating before the `global_class_create_failed` read-back verification block.
2. **ResponseTest::test_tool_error_response_without_data** — The test `WP_Error` stub defaulted `$data` to `''`; `Response::tool_error()` treated that as scalar data and emitted a `data` key. Real WordPress returns `null` for unset error data.

## Changes

- Widen `create_global_class` extract window to 3000 chars (matches `update_global_class`)
- WP_Error stub constructor default `$data` → `null`
- `Response::tool_error()` skips empty-string error data

## Test plan

- [x] Local Codex review clean (0 findings)
- [ ] CI Unit Tests — all 102 tests pass

@codex review